### PR TITLE
Remove unused dependency on `swagger` (not `swagger2`)

### DIFF
--- a/autodocodec/autodocodec.cabal
+++ b/autodocodec/autodocodec.cabal
@@ -39,7 +39,6 @@ library
     , containers
     , mtl
     , scientific
-    , swagger
     , text
     , unordered-containers
     , vector

--- a/autodocodec/package.yaml
+++ b/autodocodec/package.yaml
@@ -18,7 +18,6 @@ library:
   - containers
   - mtl
   - scientific
-  - swagger
   - text
   - unordered-containers
   - vector


### PR DESCRIPTION
I tried building the `autodocodec` package with `cabal-install` as well instead of just `stack`, and stumbled over this dependency which looks out of place, given that it's probably unmaintained and `swagger2` is used everywhere else.

It also seems to build without it, so maybe it was a typo? (Of course, just close this if it was intentional after all!).