### PR TITLE
Combine enum schemas if they have the same type

### DIFF
--- a/autodocodec-api-usage/test_resources/openapi-schema/declareSchemaRef/example.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/declareSchemaRef/example.json
@@ -16,31 +16,12 @@
                     "description": "a text"
                 },
                 "fruit": {
-                    "anyOf": [
-                        {
-                            "type": "string",
-                            "enum": [
-                                "Apple"
-                            ]
-                        },
-                        {
-                            "type": "string",
-                            "enum": [
-                                "Orange"
-                            ]
-                        },
-                        {
-                            "type": "string",
-                            "enum": [
-                                "Banana"
-                            ]
-                        },
-                        {
-                            "type": "string",
-                            "enum": [
-                                "Melon"
-                            ]
-                        }
+                    "type": "string",
+                    "enum": [
+                        "Apple",
+                        "Orange",
+                        "Banana",
+                        "Melon"
                     ],
                     "additionalProperties": true,
                     "description": "fruit!!"

--- a/autodocodec-api-usage/test_resources/openapi-schema/declareSchemaRef/fruit.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/declareSchemaRef/fruit.json
@@ -1,30 +1,11 @@
 {
     "reference": {
-        "anyOf": [
-            {
-                "type": "string",
-                "enum": [
-                    "Apple"
-                ]
-            },
-            {
-                "type": "string",
-                "enum": [
-                    "Orange"
-                ]
-            },
-            {
-                "type": "string",
-                "enum": [
-                    "Banana"
-                ]
-            },
-            {
-                "type": "string",
-                "enum": [
-                    "Melon"
-                ]
-            }
+        "type": "string",
+        "enum": [
+            "Apple",
+            "Orange",
+            "Banana",
+            "Melon"
         ],
         "additionalProperties": true
     },

--- a/autodocodec-api-usage/test_resources/openapi-schema/example.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/example.json
@@ -43,31 +43,12 @@
                         "description": "an optional list of texts with a default empty list where the empty list would be omitted"
                     },
                     "fruit": {
-                        "anyOf": [
-                            {
-                                "type": "string",
-                                "enum": [
-                                    "Apple"
-                                ]
-                            },
-                            {
-                                "type": "string",
-                                "enum": [
-                                    "Orange"
-                                ]
-                            },
-                            {
-                                "type": "string",
-                                "enum": [
-                                    "Banana"
-                                ]
-                            },
-                            {
-                                "type": "string",
-                                "enum": [
-                                    "Melon"
-                                ]
-                            }
+                        "type": "string",
+                        "enum": [
+                            "Apple",
+                            "Orange",
+                            "Banana",
+                            "Melon"
                         ],
                         "additionalProperties": true,
                         "description": "fruit!!"

--- a/autodocodec-api-usage/test_resources/openapi-schema/fruit.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/fruit.json
@@ -2,31 +2,12 @@
     "components": {
         "schemas": {
             "Fruit": {
-                "anyOf": [
-                    {
-                        "type": "string",
-                        "enum": [
-                            "Apple"
-                        ]
-                    },
-                    {
-                        "type": "string",
-                        "enum": [
-                            "Orange"
-                        ]
-                    },
-                    {
-                        "type": "string",
-                        "enum": [
-                            "Banana"
-                        ]
-                    },
-                    {
-                        "type": "string",
-                        "enum": [
-                            "Melon"
-                        ]
-                    }
+                "type": "string",
+                "enum": [
+                    "Apple",
+                    "Orange",
+                    "Banana",
+                    "Melon"
                 ],
                 "additionalProperties": true
             }

--- a/autodocodec-api-usage/test_resources/openapi-schema/ordering.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/ordering.json
@@ -2,25 +2,11 @@
     "components": {
         "schemas": {
             "Ordering": {
-                "anyOf": [
-                    {
-                        "type": "string",
-                        "enum": [
-                            "LT"
-                        ]
-                    },
-                    {
-                        "type": "string",
-                        "enum": [
-                            "EQ"
-                        ]
-                    },
-                    {
-                        "type": "string",
-                        "enum": [
-                            "GT"
-                        ]
-                    }
+                "type": "string",
+                "enum": [
+                    "LT",
+                    "EQ",
+                    "GT"
                 ],
                 "additionalProperties": true
             }

--- a/autodocodec-openapi3/CHANGELOG.md
+++ b/autodocodec-openapi3/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### Changed
+* When combining alternative enum schemas, combine the enum values into one enum if they have the same type.
+
 ## [0.2.0.0] - 2022-04-05
 
 ### Changed


### PR DESCRIPTION
This change produces cleaner and simpler schemas for enum types. E.g. instead of
```json
{
   "oneOf": [
      {
        "type": "string",
        "enum": ["Apple"]
      },
      {
        "type": "string",
        "enum": ["Orange"]
      }
  ]
}
```
we produce
```json
{
  "type": "string",
  "enum": ["Apple", "Orange"]
}
```
This should make it easier to browse the types in Swagger UI and also make it easier for code generators to produce good enum types.