### PR TITLE
Set default on property schema and not on the object level

### DIFF
--- a/autodocodec-api-usage/test_resources/openapi-schema/declareSchemaRef/example.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/declareSchemaRef/example.json
@@ -4,31 +4,18 @@
     },
     "definitions": {
         "Example": {
+            "required": [
+                "text",
+                "bool",
+                "maybe",
+                "fruit"
+            ],
             "type": "object",
             "properties": {
                 "maybe": {
                     "type": "string",
                     "description": "a maybe text",
                     "nullable": true
-                },
-                "text": {
-                    "type": "string",
-                    "description": "a text"
-                },
-                "fruit": {
-                    "type": "string",
-                    "enum": [
-                        "Apple",
-                        "Orange",
-                        "Banana",
-                        "Melon"
-                    ],
-                    "additionalProperties": true,
-                    "description": "fruit!!"
-                },
-                "optional": {
-                    "type": "string",
-                    "description": "an optional text"
                 },
                 "single-or-list": {
                     "anyOf": [
@@ -42,17 +29,35 @@
                             "type": "array"
                         }
                     ],
+                    "default": [],
                     "additionalProperties": true,
                     "description": "an optional list that can also be specified as a single element"
                 },
+                "text": {
+                    "type": "string",
+                    "description": "a text"
+                },
                 "optional-with-null-default": {
+                    "default": [],
                     "items": {
                         "type": "string"
                     },
                     "type": "array",
                     "description": "an optional list of texts with a default empty list where the empty list would be omitted"
                 },
+                "fruit": {
+                    "additionalProperties": true,
+                    "type": "string",
+                    "enum": [
+                        "Apple",
+                        "Orange",
+                        "Banana",
+                        "Melon"
+                    ],
+                    "description": "fruit!!"
+                },
                 "optional-with-default": {
+                    "default": "foobar",
                     "type": "string",
                     "description": "an optional text with a default"
                 },
@@ -64,15 +69,12 @@
                 "bool": {
                     "type": "boolean",
                     "description": "a bool"
+                },
+                "optional": {
+                    "type": "string",
+                    "description": "an optional text"
                 }
-            },
-            "default": [],
-            "required": [
-                "text",
-                "bool",
-                "maybe",
-                "fruit"
-            ]
+            }
         }
     }
 }

--- a/autodocodec-api-usage/test_resources/openapi-schema/example.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/example.json
@@ -2,7 +2,6 @@
     "components": {
         "schemas": {
             "Example": {
-                "default": [],
                 "required": [
                     "text",
                     "bool",
@@ -28,6 +27,7 @@
                                 "type": "array"
                             }
                         ],
+                        "default": [],
                         "additionalProperties": true,
                         "description": "an optional list that can also be specified as a single element"
                     },
@@ -36,6 +36,7 @@
                         "description": "a text"
                     },
                     "optional-with-null-default": {
+                        "default": [],
                         "items": {
                             "type": "string"
                         },
@@ -43,6 +44,7 @@
                         "description": "an optional list of texts with a default empty list where the empty list would be omitted"
                     },
                     "fruit": {
+                        "additionalProperties": true,
                         "type": "string",
                         "enum": [
                             "Apple",
@@ -50,10 +52,10 @@
                             "Banana",
                             "Melon"
                         ],
-                        "additionalProperties": true,
                         "description": "fruit!!"
                     },
                     "optional-with-default": {
+                        "default": "foobar",
                         "type": "string",
                         "description": "an optional text with a default"
                     },

--- a/autodocodec-openapi3/CHANGELOG.md
+++ b/autodocodec-openapi3/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Changed
 * When combining alternative enum schemas, combine the enum values into one enum if they have the same type.
+* Set default value on the property level instead of object level to fix generation of invalid schemas caused by the default value not matching the type of the object schema
 
 ## [0.2.0.0] - 2022-04-05
 

--- a/autodocodec-openapi3/src/Autodocodec/OpenAPI/Schema.hs
+++ b/autodocodec-openapi3/src/Autodocodec/OpenAPI/Schema.hs
@@ -163,10 +163,10 @@ declareNamedSchemaVia c' Proxy = evalStateT (go c') mempty
       OptionalKeyWithDefaultCodec key vs defaultValue mDoc -> do
         ns <- go vs
         ref <- declareSpecificNamedSchemaRef ns
+        let addDefaultToSchema propertySchema = propertySchema {_schemaDefault = Just $ toJSONVia vs defaultValue}
         pure
           [ mempty
-              { _schemaProperties = [(key, addMDoc mDoc . _namedSchemaSchema <$> ref)],
-                _schemaDefault = Just $ toJSONVia vs defaultValue,
+              { _schemaProperties = [(key, addDefaultToSchema . addMDoc mDoc . _namedSchemaSchema <$> ref)],
                 _schemaType = Just OpenApiObject
               }
           ]


### PR DESCRIPTION
Currently, generating OpenAPI schemas with codecs such as `optionalFieldWithDefault` lead to an invalid OpenAPI spec as can be seen by supplying `autodocodec-api-usage/test_resources/openapi-schema/example.json` to https://validator.swagger.io ([full link](https://validator.swagger.io/validator/debug?url=https%3A%2F%2Fraw.githubusercontent.com%2FNorfairKing%2Fautodocodec%2F7c0382f6a5ab10694603b38ea9534164126c1ed2%2Fautodocodec-api-usage%2Ftest_resources%2Fopenapi-schema%2Fexample.json):

```json
{"messages":["attribute components.schemas.Example.default is not of type `object`"]}
```

The reason is that the supplied default value does not match the schema of the object, which makes sense given the default value was supplied to a field of the object and not the object itself. This also leads to default values of different fields overwriting each other as there can only be one default value on the object level.

This PR aims to fix this bug by setting the default value on the property level. This leads to a valid OpenAPI spec as can be seen [here](https://validator.swagger.io/validator/debug?url=https%3A%2F%2Fraw.githubusercontent.com%2Fjoelfisch%2Fautodocodec%2F614233788828c2542425f09856cf644e56a28298%2Fautodocodec-api-usage%2Ftest_resources%2Fopenapi-schema%2Fexample.json) (empty object means no validation errors):

```json
{}
```