### PR TITLE
Support aeson-2

### DIFF
--- a/autodocodec/autodocodec.cabal
+++ b/autodocodec/autodocodec.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.5.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 
@@ -27,6 +27,7 @@ library
   exposed-modules:
       Autodocodec
       Autodocodec.Aeson
+      Autodocodec.Aeson.Compat
       Autodocodec.Aeson.Decode
       Autodocodec.Aeson.Encode
       Autodocodec.Class

--- a/autodocodec/src/Autodocodec/Aeson/Compat.hs
+++ b/autodocodec/src/Autodocodec/Aeson/Compat.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE CPP #-}
+
+module Autodocodec.Aeson.Compat where
+
+#if MIN_VERSION_aeson(2,0,0)
+import Data.Aeson.Key (Key)
+import qualified Data.Aeson.Key as K
+import qualified Data.Aeson.KeyMap as KM
+#else
+import qualified Data.HashMap.Strict as HM
+#endif
+import Data.Text (Text)
+
+#if MIN_VERSION_aeson(2,0,0)
+toKey :: Text -> Key
+toKey = K.fromText
+#else
+toKey :: Text -> Text
+toKey = id
+#endif
+
+#if MIN_VERSION_aeson(2,0,0)
+fromKey :: Key -> Text
+fromKey = K.toText
+#else
+fromKey :: Text -> Text
+fromKey = id
+#endif
+
+#if MIN_VERSION_aeson(2,0,0)
+lookupKey :: Key -> KM.KeyMap v -> Maybe v
+lookupKey = KM.lookup
+#else
+lookupKey :: Text -> HM.HashMap Text v -> Maybe v
+lookupKey = HM.lookup
+#endif
+
+#if MIN_VERSION_aeson(2,0,0)
+fromList :: [(Key, v)] -> KM.KeyMap v
+fromList = KM.fromList
+#else
+fromList :: [(Text, v)] -> HM.HashMap Text v
+fromList = HM.fromList
+#endif

--- a/autodocodec/src/Autodocodec/Aeson/Decode.hs
+++ b/autodocodec/src/Autodocodec/Aeson/Decode.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -6,14 +7,17 @@
 
 module Autodocodec.Aeson.Decode where
 
+import qualified Autodocodec.Aeson.Compat as Compat
 import Autodocodec.Class
 import Autodocodec.Codec
 import Autodocodec.DerivingVia
 import Control.Monad
 import Data.Aeson as JSON
+#if MIN_VERSION_aeson(2,0,0)
+import Data.Aeson.KeyMap (KeyMap)
+#endif
 import Data.Aeson.Types as JSON
 import Data.HashMap.Strict (HashMap)
-import qualified Data.HashMap.Strict as HM
 import Data.Map (Map)
 import qualified Data.Text as T
 import Data.Vector (Vector)
@@ -77,6 +81,9 @@ parseJSONContextVia codec_ context_ =
           (\object_ -> (`go` c) (object_ :: JSON.Object))
       HashMapCodec c -> liftParseJSON (`go` c) (`go` listCodec c) value :: JSON.Parser (HashMap _ _)
       MapCodec c -> liftParseJSON (`go` c) (`go` listCodec c) value :: JSON.Parser (Map _ _)
+#if MIN_VERSION_aeson(2,0,0)
+      KeyMapCodec c -> liftParseJSON (`go` c) (`go` listCodec c) value :: JSON.Parser (KeyMap _)
+#endif
       ValueCodec -> pure (value :: JSON.Value)
       EqCodec expected c -> do
         actual <- go value c
@@ -111,16 +118,18 @@ parseJSONContextVia codec_ context_ =
       CommentCodec _ c -> go value c
       ReferenceCodec _ c -> go value c
       RequiredKeyCodec k c _ -> do
-        valueAtKey <- (value :: JSON.Object) JSON..: k
-        go valueAtKey c JSON.<?> Key k
+        valueAtKey <- (value :: JSON.Object) JSON..: Compat.toKey k
+        go valueAtKey c JSON.<?> Key (Compat.toKey k)
       OptionalKeyCodec k c _ -> do
-        let mValueAtKey = HM.lookup k (value :: JSON.Object)
-        forM mValueAtKey $ \valueAtKey -> go (valueAtKey :: JSON.Value) c JSON.<?> Key k
+        let key = Compat.toKey k
+            mValueAtKey = Compat.lookupKey key (value :: JSON.Object)
+        forM mValueAtKey $ \valueAtKey -> go (valueAtKey :: JSON.Value) c JSON.<?> Key key
       OptionalKeyWithDefaultCodec k c defaultValue _ -> do
-        let mValueAtKey = HM.lookup k (value :: JSON.Object)
+        let key = Compat.toKey k
+            mValueAtKey = Compat.lookupKey key (value :: JSON.Object)
         case mValueAtKey of
           Nothing -> pure defaultValue
-          Just valueAtKey -> go (valueAtKey :: JSON.Value) c JSON.<?> Key k
+          Just valueAtKey -> go (valueAtKey :: JSON.Value) c JSON.<?> Key key
       OptionalKeyWithOmittedDefaultCodec k c defaultValue mDoc -> go value $ OptionalKeyWithDefaultCodec k c defaultValue mDoc
       PureCodec a -> pure a
       ApCodec ocf oca -> go (value :: JSON.Object) ocf <*> go (value :: JSON.Object) oca

--- a/autodocodec/src/Autodocodec/Class.hs
+++ b/autodocodec/src/Autodocodec/Class.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedLists #-}
@@ -9,6 +10,9 @@ module Autodocodec.Class where
 import Autodocodec.Codec
 import Data.Aeson (FromJSONKey, ToJSONKey)
 import qualified Data.Aeson as JSON
+#if MIN_VERSION_aeson(2,0,0)
+import Data.Aeson.KeyMap (KeyMap)
+#endif
 import Data.HashMap.Strict (HashMap)
 import Data.Hashable (Hashable)
 import Data.Int
@@ -121,6 +125,11 @@ instance (Ord k, FromJSONKey k, ToJSONKey k, HasCodec v) => HasCodec (Map k v) w
 
 instance (Eq k, Hashable k, FromJSONKey k, ToJSONKey k, HasCodec v) => HasCodec (HashMap k v) where
   codec = HashMapCodec codec
+
+#if MIN_VERSION_aeson(2,0,0)
+instance HasCodec v => HasCodec (KeyMap v) where
+  codec = KeyMapCodec codec
+#endif
 
 -- TODO make these instances better once aeson exposes its @Data.Aeson.Parser.Time@ or @Data.Attoparsec.Time@ modules.
 instance HasCodec Day where


### PR DESCRIPTION
This PR attempts to add support for `aeson-2`. In particular, when `aeson >= 2`, it adds (via CPP) a new constructor to the `Codec` GADT for `aeson-2`'s `KeyMap` type.

This PR asses the `autodocodec-doctest` test suite, and fails the `autodocodec-api-usage-test` test suite in the same way as the current master branch.

I'm not sure if the approach taken in this PR is the right approach, but I thought I'd show you and see what you think. I'd also be happy to work on whatever needs to be done to add support for `aeson-2`!


