### PR TITLE
Fix compatibilities with mtl 2.3.1

### DIFF
--- a/autodocodec-schema/src/Autodocodec/Schema.hs
+++ b/autodocodec-schema/src/Autodocodec/Schema.hs
@@ -11,6 +11,7 @@ module Autodocodec.Schema where
 
 import Autodocodec
 import qualified Autodocodec.Aeson.Compat as Compat
+import Control.Monad
 import Control.Monad.State
 import Data.Aeson (FromJSON (..), ToJSON (..))
 import qualified Data.Aeson as JSON

--- a/autodocodec/src/Autodocodec/Codec.hs
+++ b/autodocodec/src/Autodocodec/Codec.hs
@@ -13,6 +13,7 @@
 
 module Autodocodec.Codec where
 
+import Control.Monad
 import Control.Monad.State
 import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
 import qualified Data.Aeson as JSON


### PR DESCRIPTION
No longer the version of mtl re-exports Control.Monad (and other modules), so instead we need to import this module directly to use some monad utilities.

NOTE: Stackage hasn't supported mtl 2.3.1 yet, but it has already been released on Hackage.