### PR TITLE
Newtype derivable codec class

### DIFF
--- a/autodocodec-api-usage/autodocodec-api-usage.cabal
+++ b/autodocodec-api-usage/autodocodec-api-usage.cabal
@@ -39,13 +39,16 @@ extra-source-files:
     test_resources/json-schema/ainur.json
     test_resources/json-schema/bool.json
     test_resources/json-schema/char.json
+    test_resources/json-schema/const.json
     test_resources/json-schema/day.json
     test_resources/json-schema/difftime.json
+    test_resources/json-schema/dual.json
     test_resources/json-schema/either-bool-text.json
     test_resources/json-schema/either-either-bool-scientific-text.json
     test_resources/json-schema/example.json
     test_resources/json-schema/expression.json
     test_resources/json-schema/fruit.json
+    test_resources/json-schema/identity.json
     test_resources/json-schema/int.json
     test_resources/json-schema/int16.json
     test_resources/json-schema/int32.json
@@ -60,6 +63,8 @@ extra-source-files:
     test_resources/json-schema/local-time.json
     test_resources/json-schema/map-text-ind.json
     test_resources/json-schema/maybe-text.json
+    test_resources/json-schema/monoid-first.json
+    test_resources/json-schema/monoid-last.json
     test_resources/json-schema/mutually-recursive.json
     test_resources/json-schema/natural.json
     test_resources/json-schema/nominal-difftime.json
@@ -69,6 +74,8 @@ extra-source-files:
     test_resources/json-schema/ordering.json
     test_resources/json-schema/recursive.json
     test_resources/json-schema/scientific.json
+    test_resources/json-schema/semigroup-first.json
+    test_resources/json-schema/semigroup-last.json
     test_resources/json-schema/set-text.json
     test_resources/json-schema/string.json
     test_resources/json-schema/text.json
@@ -88,8 +95,10 @@ extra-source-files:
     test_resources/nix/ainur-type.nix
     test_resources/nix/bool-type.nix
     test_resources/nix/char-type.nix
+    test_resources/nix/const-type.nix
     test_resources/nix/day-type.nix
     test_resources/nix/difftime-type.nix
+    test_resources/nix/dual-type.nix
     test_resources/nix/either-bool-text-type.nix
     test_resources/nix/either-either-bool-scientific-text-type.nix
     test_resources/nix/example-options.nix
@@ -97,6 +106,7 @@ extra-source-files:
     test_resources/nix/expression-options.nix
     test_resources/nix/expression-type.nix
     test_resources/nix/fruit-type.nix
+    test_resources/nix/identity-type.nix
     test_resources/nix/int-type.nix
     test_resources/nix/int16-type.nix
     test_resources/nix/int32-type.nix
@@ -114,6 +124,8 @@ extra-source-files:
     test_resources/nix/local-time-type.nix
     test_resources/nix/map-text-ind-type.nix
     test_resources/nix/maybe-text-type.nix
+    test_resources/nix/monoid-first-type.nix
+    test_resources/nix/monoid-last-type.nix
     test_resources/nix/mutually-recursive-type.nix
     test_resources/nix/natural-type.nix
     test_resources/nix/nominal-difftime-type.nix
@@ -123,6 +135,8 @@ extra-source-files:
     test_resources/nix/ordering-type.nix
     test_resources/nix/recursive-type.nix
     test_resources/nix/scientific-type.nix
+    test_resources/nix/semigroup-first-type.nix
+    test_resources/nix/semigroup-last-type.nix
     test_resources/nix/set-text-type.nix
     test_resources/nix/string-type.nix
     test_resources/nix/text-type.nix
@@ -144,29 +158,39 @@ extra-source-files:
     test_resources/openapi-schema/ainur.json
     test_resources/openapi-schema/bool.json
     test_resources/openapi-schema/char.json
+    test_resources/openapi-schema/const.json
     test_resources/openapi-schema/day.json
     test_resources/openapi-schema/declareSchemaRef/ainur.json
+    test_resources/openapi-schema/declareSchemaRef/const.json
+    test_resources/openapi-schema/declareSchemaRef/dual.json
     test_resources/openapi-schema/declareSchemaRef/example.json
     test_resources/openapi-schema/declareSchemaRef/expression.json
     test_resources/openapi-schema/declareSchemaRef/fruit.json
+    test_resources/openapi-schema/declareSchemaRef/identity.json
     test_resources/openapi-schema/declareSchemaRef/legacy-object.json
     test_resources/openapi-schema/declareSchemaRef/legacy-value.json
     test_resources/openapi-schema/declareSchemaRef/lists-example.json
+    test_resources/openapi-schema/declareSchemaRef/monoid-first.json
+    test_resources/openapi-schema/declareSchemaRef/monoid-last.json
     test_resources/openapi-schema/declareSchemaRef/mutually-recursive.json
     test_resources/openapi-schema/declareSchemaRef/null.json
     test_resources/openapi-schema/declareSchemaRef/recursive.json
+    test_resources/openapi-schema/declareSchemaRef/semigroup-first.json
+    test_resources/openapi-schema/declareSchemaRef/semigroup-last.json
     test_resources/openapi-schema/declareSchemaRef/these.json
     test_resources/openapi-schema/declareSchemaRef/very-comment.json
     test_resources/openapi-schema/declareSchemaRef/via.json
     test_resources/openapi-schema/declareSchemaRef/void.json
     test_resources/openapi-schema/declareSchemaRef/war.json
     test_resources/openapi-schema/difftime.json
+    test_resources/openapi-schema/dual.json
     test_resources/openapi-schema/either-bool-text.json
     test_resources/openapi-schema/either-either-bool-scientific-text.json
     test_resources/openapi-schema/either-void-bool.json
     test_resources/openapi-schema/example.json
     test_resources/openapi-schema/expression.json
     test_resources/openapi-schema/fruit.json
+    test_resources/openapi-schema/identity.json
     test_resources/openapi-schema/int.json
     test_resources/openapi-schema/int16.json
     test_resources/openapi-schema/int32.json
@@ -181,6 +205,8 @@ extra-source-files:
     test_resources/openapi-schema/local-time.json
     test_resources/openapi-schema/map-text-int.json
     test_resources/openapi-schema/maybe-text.json
+    test_resources/openapi-schema/monoid-first.json
+    test_resources/openapi-schema/monoid-last.json
     test_resources/openapi-schema/mutually-recursive.json
     test_resources/openapi-schema/natural.json
     test_resources/openapi-schema/nominal-difftime.json
@@ -190,6 +216,8 @@ extra-source-files:
     test_resources/openapi-schema/ordering.json
     test_resources/openapi-schema/recursive.json
     test_resources/openapi-schema/scientific.json
+    test_resources/openapi-schema/semigroup-first.json
+    test_resources/openapi-schema/semigroup-last.json
     test_resources/openapi-schema/set-text.json
     test_resources/openapi-schema/string.json
     test_resources/openapi-schema/text.json
@@ -210,13 +238,16 @@ extra-source-files:
     test_resources/show-codec/ainur.txt
     test_resources/show-codec/bool.txt
     test_resources/show-codec/char.txt
+    test_resources/show-codec/const.txt
     test_resources/show-codec/day.txt
+    test_resources/show-codec/dual.txt
     test_resources/show-codec/either-bool-text.txt
     test_resources/show-codec/either-either-bool-scientific-text.txt
     test_resources/show-codec/either-void-bool.txt
     test_resources/show-codec/example.txt
     test_resources/show-codec/expression.txt
     test_resources/show-codec/fruit.txt
+    test_resources/show-codec/identity.txt
     test_resources/show-codec/int.txt
     test_resources/show-codec/int16.txt
     test_resources/show-codec/int32.txt
@@ -231,6 +262,8 @@ extra-source-files:
     test_resources/show-codec/local-time.txt
     test_resources/show-codec/map-text-int.txt
     test_resources/show-codec/maybe-text.txt
+    test_resources/show-codec/monoid-first.txt
+    test_resources/show-codec/monoid-last.txt
     test_resources/show-codec/mutually-recursive.txt
     test_resources/show-codec/natural.txt
     test_resources/show-codec/nonempty-text.txt
@@ -239,6 +272,8 @@ extra-source-files:
     test_resources/show-codec/ordering.txt
     test_resources/show-codec/recursive.txt
     test_resources/show-codec/scientific.txt
+    test_resources/show-codec/semigroup-first.txt
+    test_resources/show-codec/semigroup-last.txt
     test_resources/show-codec/set-text.txt
     test_resources/show-codec/string.txt
     test_resources/show-codec/text.txt
@@ -260,14 +295,17 @@ extra-source-files:
     test_resources/swagger-schema/ainur.json
     test_resources/swagger-schema/bool.json
     test_resources/swagger-schema/char.json
+    test_resources/swagger-schema/const.json
     test_resources/swagger-schema/day.json
     test_resources/swagger-schema/difftime.json
+    test_resources/swagger-schema/dual.json
     test_resources/swagger-schema/either-bool-text.json
     test_resources/swagger-schema/either-either-bool-scientific-text.json
     test_resources/swagger-schema/either-void-bool.json
     test_resources/swagger-schema/example.json
     test_resources/swagger-schema/expression.json
     test_resources/swagger-schema/fruit.json
+    test_resources/swagger-schema/identity.json
     test_resources/swagger-schema/int.json
     test_resources/swagger-schema/int16.json
     test_resources/swagger-schema/int32.json
@@ -282,6 +320,8 @@ extra-source-files:
     test_resources/swagger-schema/local-time.json
     test_resources/swagger-schema/map-text-int.json
     test_resources/swagger-schema/maybe-text.json
+    test_resources/swagger-schema/monoid-first.json
+    test_resources/swagger-schema/monoid-last.json
     test_resources/swagger-schema/mutually-recursive.json
     test_resources/swagger-schema/natural.json
     test_resources/swagger-schema/nominal-difftime.json
@@ -291,6 +331,8 @@ extra-source-files:
     test_resources/swagger-schema/ordering.json
     test_resources/swagger-schema/recursive.json
     test_resources/swagger-schema/scientific.json
+    test_resources/swagger-schema/semigroup-first.json
+    test_resources/swagger-schema/semigroup-last.json
     test_resources/swagger-schema/set-text.json
     test_resources/swagger-schema/string.json
     test_resources/swagger-schema/text.json

--- a/autodocodec-api-usage/src/Autodocodec/Usage.hs
+++ b/autodocodec-api-usage/src/Autodocodec/Usage.hs
@@ -23,6 +23,7 @@ import Control.Applicative
 import Control.DeepSeq
 import Data.Aeson (FromJSON (..), ToJSON (..))
 import qualified Data.Aeson as JSON
+import Data.Functor.Identity (Identity)
 import Data.GenValidity
 import Data.GenValidity.Aeson ()
 import Data.GenValidity.Scientific ()
@@ -30,8 +31,10 @@ import Data.GenValidity.Text ()
 import qualified Data.HashMap.Strict as HashMap
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Maybe
+import qualified Data.Monoid as Monoid
 import Data.OpenApi (ToSchema)
 import qualified Data.OpenApi as OpenAPI
+import qualified Data.Semigroup as Semigroup
 import qualified Data.Swagger as Swagger
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -708,3 +711,21 @@ instance HasObjectCodec Expression where
             ("sum", ("SumExpression", mapToDecoder (uncurry SumExpression) lrFieldsCodec)),
             ("product", ("ProductExpression", mapToDecoder (uncurry ProductExpression) lrFieldsCodec))
           ]
+
+identityCodec :: (HasCodec a) => JSONCodec (Identity a)
+identityCodec = codec
+
+semigroupFirstCodec :: (HasCodec a) => JSONCodec (Semigroup.First a)
+semigroupFirstCodec = codec
+
+semigroupLastCodec :: (HasCodec a) => JSONCodec (Semigroup.Last a)
+semigroupLastCodec = codec
+
+monoidFirstCodec :: (HasCodec a) => JSONCodec (Monoid.First a)
+monoidFirstCodec = codec
+
+monoidLastCodec :: (HasCodec a) => JSONCodec (Monoid.Last a)
+monoidLastCodec = codec
+
+constCodec :: (HasCodec a) => JSONCodec (Const a b)
+constCodec = codec

--- a/autodocodec-api-usage/test/Autodocodec/Aeson/SchemaSpec.hs
+++ b/autodocodec-api-usage/test/Autodocodec/Aeson/SchemaSpec.hs
@@ -12,6 +12,8 @@ import Autodocodec.Schema
 import Autodocodec.Usage
 import qualified Data.Aeson as JSON
 import Data.Data
+import Data.Functor.Const (Const)
+import Data.Functor.Identity (Identity)
 import Data.GenValidity
 import Data.GenValidity.Aeson ()
 import Data.GenValidity.Containers ()
@@ -21,7 +23,10 @@ import Data.GenValidity.Time ()
 import Data.Int
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map (Map)
+import Data.Monoid (Dual)
+import qualified Data.Monoid as Monoid
 import Data.Scientific
+import qualified Data.Semigroup as Semigroup
 import Data.Set (Set)
 import Data.Text (Text)
 import qualified Data.Text.Lazy as LT
@@ -86,6 +91,14 @@ spec = do
   jsonSchemaSpec @War "war"
   jsonSchemaSpec @These "these"
   jsonSchemaSpec @Expression "expression"
+  jsonSchemaSpec @(Identity Text) "identity"
+  jsonSchemaSpec @(Dual Text) "dual"
+  jsonSchemaSpec @(Semigroup.First Text) "semigroup-first"
+  jsonSchemaSpec @(Semigroup.Last Text) "semigroup-last"
+  jsonSchemaSpec @(Monoid.First Text) "monoid-first"
+  jsonSchemaSpec @(Monoid.Last Text) "monoid-last"
+  jsonSchemaSpec @(Const Text Void) "const"
+
   describe "JSONSchema" $ do
     genValidSpec @JSONSchema
     xdescribe "does not hold because this property does not hold for Scientific values like -7.85483897507979979e17" $

--- a/autodocodec-api-usage/test/Autodocodec/AesonSpec.hs
+++ b/autodocodec-api-usage/test/Autodocodec/AesonSpec.hs
@@ -12,6 +12,8 @@ import qualified Data.Aeson as JSON
 import qualified Data.Aeson.Types as JSON
 import qualified Data.ByteString.Lazy as LB
 import Data.Data
+import Data.Functor.Const (Const)
+import Data.Functor.Identity (Identity)
 import Data.GenValidity
 import Data.GenValidity.Aeson ()
 import Data.GenValidity.Containers ()
@@ -21,12 +23,16 @@ import Data.GenValidity.Time ()
 import Data.Int
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map (Map)
+import Data.Monoid (Dual)
+import qualified Data.Monoid as Monoid
 import Data.Scientific
+import qualified Data.Semigroup as Semigroup
 import Data.Set (Set)
 import Data.Text (Text)
 import qualified Data.Text.Lazy as LT
 import Data.Time
 import Data.Vector (Vector)
+import Data.Void (Void)
 import Data.Word
 import Numeric.Natural
 import Test.Syd
@@ -103,6 +109,13 @@ spec = do
   aesonCodecSpec @War
   aesonCodecSpec @These
   aesonCodecSpec @Expression
+  aesonCodecSpec @(Identity Text)
+  aesonCodecSpec @(Dual Text)
+  aesonCodecSpec @(Semigroup.First Text)
+  aesonCodecSpec @(Semigroup.Last Text)
+  aesonCodecSpec @(Monoid.First Text)
+  aesonCodecSpec @(Monoid.Last Text)
+  aesonCodecSpec @(Const Text Void)
 
 aesonCodecErrorSpec ::
   forall a.

--- a/autodocodec-api-usage/test/Autodocodec/NixSpec.hs
+++ b/autodocodec-api-usage/test/Autodocodec/NixSpec.hs
@@ -10,10 +10,15 @@ import Autodocodec
 import Autodocodec.Nix
 import Autodocodec.Usage
 import qualified Data.Aeson as JSON
+import Data.Functor.Const (Const)
+import Data.Functor.Identity (Identity)
 import Data.Int
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map (Map)
+import qualified Data.Monoid as Monoid
 import Data.Scientific
+import Data.Semigroup (Dual)
+import qualified Data.Semigroup as Semigroup
 import Data.Set (Set)
 import Data.Text (Text)
 import qualified Data.Text.Lazy as LT
@@ -81,6 +86,13 @@ spec = do
   nixOptionsSpec @These "these"
   nixOptionTypeSpec @Expression "expression"
   nixOptionsSpec @Expression "expression"
+  nixOptionTypeSpec @(Identity Text) "identity"
+  nixOptionTypeSpec @(Dual Text) "dual"
+  nixOptionTypeSpec @(Semigroup.First Text) "semigroup-first"
+  nixOptionTypeSpec @(Semigroup.Last Text) "semigroup-last"
+  nixOptionTypeSpec @(Monoid.First Text) "monoid-first"
+  nixOptionTypeSpec @(Monoid.Last Text) "monoid-last"
+  nixOptionTypeSpec @(Const Text Void) "const"
 
 nixOptionsSpec ::
   forall a.

--- a/autodocodec-api-usage/test/Autodocodec/OpenAPISpec.hs
+++ b/autodocodec-api-usage/test/Autodocodec/OpenAPISpec.hs
@@ -12,6 +12,8 @@ import Autodocodec.OpenAPI
 import Autodocodec.Usage
 import qualified Data.Aeson as JSON
 import Data.Data
+import Data.Functor.Const (Const)
+import Data.Functor.Identity (Identity)
 import Data.GenValidity.Aeson ()
 import Data.GenValidity.Containers ()
 import Data.GenValidity.Scientific ()
@@ -21,10 +23,13 @@ import Data.Int
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map (Map)
 import Data.Maybe
+import qualified Data.Monoid as Monoid
 import Data.OpenApi (Components (..), OpenApi (..))
 import qualified Data.OpenApi as OpenAPI
 import qualified Data.OpenApi.Declare as OpenAPI
 import Data.Scientific
+import Data.Semigroup (Dual)
+import qualified Data.Semigroup as Semigroup
 import Data.Set (Set)
 import Data.Text (Text)
 import qualified Data.Text as T
@@ -37,6 +42,11 @@ import Numeric.Natural
 import Test.Syd
 import Test.Syd.Aeson
 import Test.Syd.Validity.Utils
+
+openAPISchemaSpecAndViaDeclareSchemaRef :: forall a. (Typeable a, HasCodec a) => FilePath -> Spec
+openAPISchemaSpecAndViaDeclareSchemaRef filePath = do
+  openAPISchemaSpec @a filePath
+  openAPISchemaSpecViaDeclareSchemaRef @a filePath
 
 spec :: Spec
 spec = do
@@ -107,6 +117,13 @@ spec = do
   openAPISchemaSpecViaDeclareSchemaRef @These "these"
   openAPISchemaSpec @Expression "expression"
   openAPISchemaSpecViaDeclareSchemaRef @Expression "expression"
+  openAPISchemaSpecAndViaDeclareSchemaRef @(Identity Text) "identity"
+  openAPISchemaSpecAndViaDeclareSchemaRef @(Dual Text) "dual"
+  openAPISchemaSpecAndViaDeclareSchemaRef @(Semigroup.First Text) "semigroup-first"
+  openAPISchemaSpecAndViaDeclareSchemaRef @(Semigroup.Last Text) "semigroup-last"
+  openAPISchemaSpecAndViaDeclareSchemaRef @(Monoid.First Text) "monoid-first"
+  openAPISchemaSpecAndViaDeclareSchemaRef @(Monoid.Last Text) "monoid-last"
+  openAPISchemaSpecAndViaDeclareSchemaRef @(Const Text Void) "const"
 
 openAPISchemaSpec :: forall a. (Typeable a, HasCodec a) => FilePath -> Spec
 openAPISchemaSpec filePath =

--- a/autodocodec-api-usage/test/Autodocodec/ShowSpec.hs
+++ b/autodocodec-api-usage/test/Autodocodec/ShowSpec.hs
@@ -9,10 +9,15 @@ import Autodocodec
 import Autodocodec.Usage
 import qualified Data.Aeson as JSON
 import Data.Data
+import Data.Functor.Const (Const)
+import Data.Functor.Identity (Identity)
 import Data.Int
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map (Map)
+import qualified Data.Monoid as Monoid
 import Data.Scientific
+import Data.Semigroup (Dual)
+import qualified Data.Semigroup as Semigroup
 import Data.Set (Set)
 import Data.Text (Text)
 import qualified Data.Text.Lazy as LT
@@ -77,6 +82,13 @@ spec = do
   showCodecSpec @War "war"
   showCodecSpec @These "these"
   showCodecSpec @Expression "expression"
+  showCodecSpec @(Identity Text) "identity"
+  showCodecSpec @(Dual Text) "dual"
+  showCodecSpec @(Semigroup.First Text) "semigroup-first"
+  showCodecSpec @(Semigroup.Last Text) "semigroup-last"
+  showCodecSpec @(Monoid.First Text) "monoid-first"
+  showCodecSpec @(Monoid.Last Text) "monoid-last"
+  showCodecSpec @(Const Text Void) "const"
 
 showCodecSpec ::
   forall a.

--- a/autodocodec-api-usage/test/Autodocodec/SwaggerSpec.hs
+++ b/autodocodec-api-usage/test/Autodocodec/SwaggerSpec.hs
@@ -12,6 +12,8 @@ import Autodocodec.Swagger
 import Autodocodec.Usage
 import qualified Data.Aeson as JSON
 import Data.Data
+import Data.Functor.Const (Const)
+import Data.Functor.Identity (Identity)
 import Data.GenValidity
 import Data.GenValidity.Aeson ()
 import Data.GenValidity.Containers ()
@@ -22,7 +24,10 @@ import Data.Int
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map (Map)
 import Data.Maybe
+import qualified Data.Monoid as Monoid
 import Data.Scientific
+import Data.Semigroup (Dual)
+import qualified Data.Semigroup as Semigroup
 import Data.Set (Set)
 import Data.Swagger (Swagger (..))
 import qualified Data.Swagger as Swagger
@@ -94,6 +99,13 @@ spec = do
   swaggerSchemaSpec @War "war"
   swaggerSchemaSpec @These "these"
   swaggerSchemaSpec @Expression "expression"
+  swaggerSchemaSpec @(Identity Text) "identity"
+  swaggerSchemaSpec @(Dual Text) "dual"
+  swaggerSchemaSpec @(Semigroup.First Text) "semigroup-first"
+  swaggerSchemaSpec @(Semigroup.Last Text) "semigroup-last"
+  swaggerSchemaSpec @(Monoid.First Text) "monoid-first"
+  swaggerSchemaSpec @(Monoid.Last Text) "monoid-last"
+  swaggerSchemaSpec @(Const Text Void) "const"
 
 swaggerSchemaSpec :: forall a. (Show a, Typeable a, GenValid a, HasCodec a) => FilePath -> Spec
 swaggerSchemaSpec filePath =

--- a/autodocodec-api-usage/test/Autodocodec/YamlSpec.hs
+++ b/autodocodec-api-usage/test/Autodocodec/YamlSpec.hs
@@ -10,6 +10,8 @@ import Autodocodec.Usage
 import Autodocodec.Yaml.Encode
 import qualified Data.Aeson as JSON
 import Data.Data
+import Data.Functor.Const (Const)
+import Data.Functor.Identity (Identity)
 import Data.GenValidity
 import Data.GenValidity.Aeson ()
 import Data.GenValidity.Containers ()
@@ -19,12 +21,16 @@ import Data.GenValidity.Time ()
 import Data.Int
 import Data.List.NonEmpty (NonEmpty)
 import Data.Map (Map)
+import qualified Data.Monoid as Monoid
 import Data.Scientific
+import Data.Semigroup (Dual)
+import qualified Data.Semigroup as Semigroup
 import Data.Set (Set)
 import Data.Text (Text)
 import qualified Data.Text.Lazy as LT
 import Data.Time
 import Data.Vector (Vector)
+import Data.Void (Void)
 import Data.Word
 import Data.Yaml as Yaml
 import Data.Yaml.Builder as YamlBuilder
@@ -83,6 +89,13 @@ spec = do
   yamlCodecSpec @War
   yamlCodecSpec @These
   yamlCodecSpec @Expression
+  yamlCodecSpec @(Identity Text)
+  yamlCodecSpec @(Dual Text)
+  yamlCodecSpec @(Semigroup.First Text)
+  yamlCodecSpec @(Semigroup.Last Text)
+  yamlCodecSpec @(Monoid.First Text)
+  yamlCodecSpec @(Monoid.Last Text)
+  yamlCodecSpec @(Const Text Void)
 
 yamlCodecSpec ::
   forall a.

--- a/autodocodec-api-usage/test_resources/json-schema/const.json
+++ b/autodocodec-api-usage/test_resources/json-schema/const.json
@@ -1,0 +1,3 @@
+{
+    "type": "string"
+}

--- a/autodocodec-api-usage/test_resources/json-schema/day.json
+++ b/autodocodec-api-usage/test_resources/json-schema/day.json
@@ -1,3 +1,4 @@
 {
-    "$comment": "Day"
+    "$comment": "Day",
+    "type": "string"
 }

--- a/autodocodec-api-usage/test_resources/json-schema/dual.json
+++ b/autodocodec-api-usage/test_resources/json-schema/dual.json
@@ -1,0 +1,3 @@
+{
+    "type": "string"
+}

--- a/autodocodec-api-usage/test_resources/json-schema/identity.json
+++ b/autodocodec-api-usage/test_resources/json-schema/identity.json
@@ -1,0 +1,3 @@
+{
+    "type": "string"
+}

--- a/autodocodec-api-usage/test_resources/json-schema/local-time.json
+++ b/autodocodec-api-usage/test_resources/json-schema/local-time.json
@@ -1,3 +1,4 @@
 {
-    "$comment": "LocalTime"
+    "$comment": "LocalTime",
+    "type": "string"
 }

--- a/autodocodec-api-usage/test_resources/json-schema/monoid-first.json
+++ b/autodocodec-api-usage/test_resources/json-schema/monoid-first.json
@@ -1,0 +1,10 @@
+{
+    "anyOf": [
+        {
+            "type": "null"
+        },
+        {
+            "type": "string"
+        }
+    ]
+}

--- a/autodocodec-api-usage/test_resources/json-schema/monoid-last.json
+++ b/autodocodec-api-usage/test_resources/json-schema/monoid-last.json
@@ -1,0 +1,10 @@
+{
+    "anyOf": [
+        {
+            "type": "null"
+        },
+        {
+            "type": "string"
+        }
+    ]
+}

--- a/autodocodec-api-usage/test_resources/json-schema/semigroup-first.json
+++ b/autodocodec-api-usage/test_resources/json-schema/semigroup-first.json
@@ -1,0 +1,3 @@
+{
+    "type": "string"
+}

--- a/autodocodec-api-usage/test_resources/json-schema/semigroup-last.json
+++ b/autodocodec-api-usage/test_resources/json-schema/semigroup-last.json
@@ -1,0 +1,3 @@
+{
+    "type": "string"
+}

--- a/autodocodec-api-usage/test_resources/json-schema/time-of-day.json
+++ b/autodocodec-api-usage/test_resources/json-schema/time-of-day.json
@@ -1,3 +1,4 @@
 {
-    "$comment": "TimeOfDay"
+    "$comment": "TimeOfDay",
+    "type": "string"
 }

--- a/autodocodec-api-usage/test_resources/json-schema/utc-time.json
+++ b/autodocodec-api-usage/test_resources/json-schema/utc-time.json
@@ -1,3 +1,4 @@
 {
-    "$comment": "LocalTime"
+    "$comment": "UTCTime",
+    "type": "string"
 }

--- a/autodocodec-api-usage/test_resources/nix/const-type.nix
+++ b/autodocodec-api-usage/test_resources/nix/const-type.nix
@@ -1,0 +1,1 @@
+types.str

--- a/autodocodec-api-usage/test_resources/nix/day-type.nix
+++ b/autodocodec-api-usage/test_resources/nix/day-type.nix
@@ -1,1 +1,1 @@
-types.unspecified
+types.str

--- a/autodocodec-api-usage/test_resources/nix/dual-type.nix
+++ b/autodocodec-api-usage/test_resources/nix/dual-type.nix
@@ -1,0 +1,1 @@
+types.str

--- a/autodocodec-api-usage/test_resources/nix/identity-type.nix
+++ b/autodocodec-api-usage/test_resources/nix/identity-type.nix
@@ -1,0 +1,1 @@
+types.str

--- a/autodocodec-api-usage/test_resources/nix/local-time-type.nix
+++ b/autodocodec-api-usage/test_resources/nix/local-time-type.nix
@@ -1,1 +1,1 @@
-types.unspecified
+types.str

--- a/autodocodec-api-usage/test_resources/nix/monoid-first-type.nix
+++ b/autodocodec-api-usage/test_resources/nix/monoid-first-type.nix
@@ -1,0 +1,4 @@
+types.oneOf [
+  (types.anything)
+  (types.str)
+]

--- a/autodocodec-api-usage/test_resources/nix/monoid-last-type.nix
+++ b/autodocodec-api-usage/test_resources/nix/monoid-last-type.nix
@@ -1,0 +1,4 @@
+types.oneOf [
+  (types.anything)
+  (types.str)
+]

--- a/autodocodec-api-usage/test_resources/nix/semigroup-first-type.nix
+++ b/autodocodec-api-usage/test_resources/nix/semigroup-first-type.nix
@@ -1,0 +1,1 @@
+types.str

--- a/autodocodec-api-usage/test_resources/nix/semigroup-last-type.nix
+++ b/autodocodec-api-usage/test_resources/nix/semigroup-last-type.nix
@@ -1,0 +1,1 @@
+types.str

--- a/autodocodec-api-usage/test_resources/nix/time-of-day-type.nix
+++ b/autodocodec-api-usage/test_resources/nix/time-of-day-type.nix
@@ -1,1 +1,1 @@
-types.unspecified
+types.str

--- a/autodocodec-api-usage/test_resources/nix/utc-time-type.nix
+++ b/autodocodec-api-usage/test_resources/nix/utc-time-type.nix
@@ -1,1 +1,1 @@
-types.unspecified
+types.str

--- a/autodocodec-api-usage/test_resources/openapi-schema/const.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/const.json
@@ -1,0 +1,15 @@
+{
+    "components": {
+        "schemas": {
+            "(Const * Text Void)": {
+                "type": "string"
+            }
+        }
+    },
+    "info": {
+        "title": "",
+        "version": ""
+    },
+    "openapi": "3.0.0",
+    "paths": {}
+}

--- a/autodocodec-api-usage/test_resources/openapi-schema/day.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/day.json
@@ -2,8 +2,8 @@
     "components": {
         "schemas": {
             "Day": {
-                "additionalProperties": true,
-                "description": "Day"
+                "description": "Day",
+                "type": "string"
             }
         }
     },

--- a/autodocodec-api-usage/test_resources/openapi-schema/declareSchemaRef/const.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/declareSchemaRef/const.json
@@ -1,0 +1,6 @@
+{
+    "definitions": {},
+    "reference": {
+        "type": "string"
+    }
+}

--- a/autodocodec-api-usage/test_resources/openapi-schema/declareSchemaRef/dual.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/declareSchemaRef/dual.json
@@ -1,0 +1,6 @@
+{
+    "definitions": {},
+    "reference": {
+        "type": "string"
+    }
+}

--- a/autodocodec-api-usage/test_resources/openapi-schema/declareSchemaRef/identity.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/declareSchemaRef/identity.json
@@ -1,0 +1,6 @@
+{
+    "definitions": {},
+    "reference": {
+        "type": "string"
+    }
+}

--- a/autodocodec-api-usage/test_resources/openapi-schema/declareSchemaRef/monoid-first.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/declareSchemaRef/monoid-first.json
@@ -1,0 +1,7 @@
+{
+    "definitions": {},
+    "reference": {
+        "nullable": true,
+        "type": "string"
+    }
+}

--- a/autodocodec-api-usage/test_resources/openapi-schema/declareSchemaRef/monoid-last.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/declareSchemaRef/monoid-last.json
@@ -1,0 +1,7 @@
+{
+    "definitions": {},
+    "reference": {
+        "nullable": true,
+        "type": "string"
+    }
+}

--- a/autodocodec-api-usage/test_resources/openapi-schema/declareSchemaRef/semigroup-first.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/declareSchemaRef/semigroup-first.json
@@ -1,0 +1,6 @@
+{
+    "definitions": {},
+    "reference": {
+        "type": "string"
+    }
+}

--- a/autodocodec-api-usage/test_resources/openapi-schema/declareSchemaRef/semigroup-last.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/declareSchemaRef/semigroup-last.json
@@ -1,0 +1,6 @@
+{
+    "definitions": {},
+    "reference": {
+        "type": "string"
+    }
+}

--- a/autodocodec-api-usage/test_resources/openapi-schema/dual.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/dual.json
@@ -1,0 +1,15 @@
+{
+    "components": {
+        "schemas": {
+            "(Dual Text)": {
+                "type": "string"
+            }
+        }
+    },
+    "info": {
+        "title": "",
+        "version": ""
+    },
+    "openapi": "3.0.0",
+    "paths": {}
+}

--- a/autodocodec-api-usage/test_resources/openapi-schema/identity.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/identity.json
@@ -1,0 +1,15 @@
+{
+    "components": {
+        "schemas": {
+            "(Identity Text)": {
+                "type": "string"
+            }
+        }
+    },
+    "info": {
+        "title": "",
+        "version": ""
+    },
+    "openapi": "3.0.0",
+    "paths": {}
+}

--- a/autodocodec-api-usage/test_resources/openapi-schema/local-time.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/local-time.json
@@ -2,8 +2,8 @@
     "components": {
         "schemas": {
             "LocalTime": {
-                "additionalProperties": true,
-                "description": "LocalTime"
+                "description": "LocalTime",
+                "type": "string"
             }
         }
     },

--- a/autodocodec-api-usage/test_resources/openapi-schema/monoid-first.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/monoid-first.json
@@ -1,0 +1,16 @@
+{
+    "components": {
+        "schemas": {
+            "(First Text)": {
+                "nullable": true,
+                "type": "string"
+            }
+        }
+    },
+    "info": {
+        "title": "",
+        "version": ""
+    },
+    "openapi": "3.0.0",
+    "paths": {}
+}

--- a/autodocodec-api-usage/test_resources/openapi-schema/monoid-last.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/monoid-last.json
@@ -1,0 +1,16 @@
+{
+    "components": {
+        "schemas": {
+            "(Last Text)": {
+                "nullable": true,
+                "type": "string"
+            }
+        }
+    },
+    "info": {
+        "title": "",
+        "version": ""
+    },
+    "openapi": "3.0.0",
+    "paths": {}
+}

--- a/autodocodec-api-usage/test_resources/openapi-schema/semigroup-first.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/semigroup-first.json
@@ -1,0 +1,15 @@
+{
+    "components": {
+        "schemas": {
+            "(First Text)": {
+                "type": "string"
+            }
+        }
+    },
+    "info": {
+        "title": "",
+        "version": ""
+    },
+    "openapi": "3.0.0",
+    "paths": {}
+}

--- a/autodocodec-api-usage/test_resources/openapi-schema/semigroup-last.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/semigroup-last.json
@@ -1,0 +1,15 @@
+{
+    "components": {
+        "schemas": {
+            "(Last Text)": {
+                "type": "string"
+            }
+        }
+    },
+    "info": {
+        "title": "",
+        "version": ""
+    },
+    "openapi": "3.0.0",
+    "paths": {}
+}

--- a/autodocodec-api-usage/test_resources/openapi-schema/time-of-day.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/time-of-day.json
@@ -2,8 +2,8 @@
     "components": {
         "schemas": {
             "TimeOfDay": {
-                "additionalProperties": true,
-                "description": "TimeOfDay"
+                "description": "TimeOfDay",
+                "type": "string"
             }
         }
     },

--- a/autodocodec-api-usage/test_resources/openapi-schema/utc-time.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/utc-time.json
@@ -2,8 +2,8 @@
     "components": {
         "schemas": {
             "UTCTime": {
-                "additionalProperties": true,
-                "description": "LocalTime"
+                "description": "UTCTime",
+                "type": "string"
             }
         }
     },

--- a/autodocodec-api-usage/test_resources/show-codec/const.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/const.txt
@@ -1,0 +1,1 @@
+StringCodec Nothing

--- a/autodocodec-api-usage/test_resources/show-codec/day.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/day.txt
@@ -1,1 +1,1 @@
-CommentCodec "Day" (BimapCodec _ _ ValueCodec)
+CommentCodec "Day" (BimapCodec _ _ (StringCodec Nothing))

--- a/autodocodec-api-usage/test_resources/show-codec/dual.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/dual.txt
@@ -1,0 +1,1 @@
+StringCodec Nothing

--- a/autodocodec-api-usage/test_resources/show-codec/identity.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/identity.txt
@@ -1,0 +1,1 @@
+StringCodec Nothing

--- a/autodocodec-api-usage/test_resources/show-codec/local-time.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/local-time.txt
@@ -1,1 +1,1 @@
-CommentCodec "LocalTime" (BimapCodec _ _ ValueCodec)
+CommentCodec "LocalTime" (BimapCodec _ _ (StringCodec Nothing))

--- a/autodocodec-api-usage/test_resources/show-codec/monoid-first.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/monoid-first.txt
@@ -1,0 +1,4 @@
+BimapCodec
+  _
+  _
+  (EitherCodec PossiblyJointUnion NullCodec (StringCodec Nothing))

--- a/autodocodec-api-usage/test_resources/show-codec/monoid-last.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/monoid-last.txt
@@ -1,0 +1,4 @@
+BimapCodec
+  _
+  _
+  (EitherCodec PossiblyJointUnion NullCodec (StringCodec Nothing))

--- a/autodocodec-api-usage/test_resources/show-codec/semigroup-first.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/semigroup-first.txt
@@ -1,0 +1,1 @@
+StringCodec Nothing

--- a/autodocodec-api-usage/test_resources/show-codec/semigroup-last.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/semigroup-last.txt
@@ -1,0 +1,1 @@
+StringCodec Nothing

--- a/autodocodec-api-usage/test_resources/show-codec/time-of-day.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/time-of-day.txt
@@ -1,1 +1,1 @@
-CommentCodec "TimeOfDay" (BimapCodec _ _ ValueCodec)
+CommentCodec "TimeOfDay" (BimapCodec _ _ (StringCodec Nothing))

--- a/autodocodec-api-usage/test_resources/show-codec/utc-time.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/utc-time.txt
@@ -1,1 +1,1 @@
-CommentCodec "LocalTime" (BimapCodec _ _ ValueCodec)
+CommentCodec "UTCTime" (BimapCodec _ _ (StringCodec Nothing))

--- a/autodocodec-api-usage/test_resources/show-codec/zoned-time.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/zoned-time.txt
@@ -1,1 +1,1 @@
-CommentCodec "ZonedTime" (BimapCodec _ _ ValueCodec)
+CommentCodec "ZonedTime" (BimapCodec _ _ (StringCodec Nothing))

--- a/autodocodec-api-usage/test_resources/swagger-schema/const.json
+++ b/autodocodec-api-usage/test_resources/swagger-schema/const.json
@@ -1,0 +1,13 @@
+{
+    "definitions": {
+        "(Const * Text Void)": {
+            "type": "string"
+        }
+    },
+    "info": {
+        "title": "",
+        "version": ""
+    },
+    "paths": {},
+    "swagger": "2.0"
+}

--- a/autodocodec-api-usage/test_resources/swagger-schema/day.json
+++ b/autodocodec-api-usage/test_resources/swagger-schema/day.json
@@ -1,8 +1,8 @@
 {
     "definitions": {
         "Day": {
-            "additionalProperties": true,
-            "description": "Day"
+            "description": "Day",
+            "type": "string"
         }
     },
     "info": {

--- a/autodocodec-api-usage/test_resources/swagger-schema/dual.json
+++ b/autodocodec-api-usage/test_resources/swagger-schema/dual.json
@@ -1,0 +1,13 @@
+{
+    "definitions": {
+        "(Dual Text)": {
+            "type": "string"
+        }
+    },
+    "info": {
+        "title": "",
+        "version": ""
+    },
+    "paths": {},
+    "swagger": "2.0"
+}

--- a/autodocodec-api-usage/test_resources/swagger-schema/identity.json
+++ b/autodocodec-api-usage/test_resources/swagger-schema/identity.json
@@ -1,0 +1,13 @@
+{
+    "definitions": {
+        "(Identity Text)": {
+            "type": "string"
+        }
+    },
+    "info": {
+        "title": "",
+        "version": ""
+    },
+    "paths": {},
+    "swagger": "2.0"
+}

--- a/autodocodec-api-usage/test_resources/swagger-schema/local-time.json
+++ b/autodocodec-api-usage/test_resources/swagger-schema/local-time.json
@@ -1,8 +1,8 @@
 {
     "definitions": {
         "LocalTime": {
-            "additionalProperties": true,
-            "description": "LocalTime"
+            "description": "LocalTime",
+            "type": "string"
         }
     },
     "info": {

--- a/autodocodec-api-usage/test_resources/swagger-schema/monoid-first.json
+++ b/autodocodec-api-usage/test_resources/swagger-schema/monoid-first.json
@@ -1,0 +1,13 @@
+{
+    "definitions": {
+        "(First Text)": {
+            "additionalProperties": true
+        }
+    },
+    "info": {
+        "title": "",
+        "version": ""
+    },
+    "paths": {},
+    "swagger": "2.0"
+}

--- a/autodocodec-api-usage/test_resources/swagger-schema/monoid-last.json
+++ b/autodocodec-api-usage/test_resources/swagger-schema/monoid-last.json
@@ -1,0 +1,13 @@
+{
+    "definitions": {
+        "(Last Text)": {
+            "additionalProperties": true
+        }
+    },
+    "info": {
+        "title": "",
+        "version": ""
+    },
+    "paths": {},
+    "swagger": "2.0"
+}

--- a/autodocodec-api-usage/test_resources/swagger-schema/semigroup-first.json
+++ b/autodocodec-api-usage/test_resources/swagger-schema/semigroup-first.json
@@ -1,0 +1,13 @@
+{
+    "definitions": {
+        "(First Text)": {
+            "type": "string"
+        }
+    },
+    "info": {
+        "title": "",
+        "version": ""
+    },
+    "paths": {},
+    "swagger": "2.0"
+}

--- a/autodocodec-api-usage/test_resources/swagger-schema/semigroup-last.json
+++ b/autodocodec-api-usage/test_resources/swagger-schema/semigroup-last.json
@@ -1,0 +1,13 @@
+{
+    "definitions": {
+        "(Last Text)": {
+            "type": "string"
+        }
+    },
+    "info": {
+        "title": "",
+        "version": ""
+    },
+    "paths": {},
+    "swagger": "2.0"
+}

--- a/autodocodec-api-usage/test_resources/swagger-schema/time-of-day.json
+++ b/autodocodec-api-usage/test_resources/swagger-schema/time-of-day.json
@@ -1,8 +1,8 @@
 {
     "definitions": {
         "TimeOfDay": {
-            "additionalProperties": true,
-            "description": "TimeOfDay"
+            "description": "TimeOfDay",
+            "type": "string"
         }
     },
     "info": {

--- a/autodocodec-api-usage/test_resources/swagger-schema/utc-time.json
+++ b/autodocodec-api-usage/test_resources/swagger-schema/utc-time.json
@@ -1,8 +1,8 @@
 {
     "definitions": {
         "UTCTime": {
-            "additionalProperties": true,
-            "description": "LocalTime"
+            "description": "UTCTime",
+            "type": "string"
         }
     },
     "info": {

--- a/autodocodec-api-usage/test_resources/swagger-schema/zoned-time.json
+++ b/autodocodec-api-usage/test_resources/swagger-schema/zoned-time.json
@@ -1,8 +1,8 @@
 {
     "definitions": {
         "ZonedTime": {
-            "additionalProperties": true,
-            "description": "ZonedTime"
+            "description": "ZonedTime",
+            "type": "string"
         }
     },
     "info": {

--- a/autodocodec-api-usage/test_resources/yaml-schema/day.txt
+++ b/autodocodec-api-usage/test_resources/yaml-schema/day.txt
@@ -1,2 +1,2 @@
 # Day
-[33m<any>[m
+[33m<string>[m

--- a/autodocodec-api-usage/test_resources/yaml-schema/local-time.txt
+++ b/autodocodec-api-usage/test_resources/yaml-schema/local-time.txt
@@ -1,2 +1,2 @@
 # LocalTime
-[33m<any>[m
+[33m<string>[m

--- a/autodocodec-api-usage/test_resources/yaml-schema/time-of-day.txt
+++ b/autodocodec-api-usage/test_resources/yaml-schema/time-of-day.txt
@@ -1,2 +1,2 @@
 # TimeOfDay
-[33m<any>[m
+[33m<string>[m

--- a/autodocodec-api-usage/test_resources/yaml-schema/utc-time.txt
+++ b/autodocodec-api-usage/test_resources/yaml-schema/utc-time.txt
@@ -1,2 +1,2 @@
-# LocalTime
-[33m<any>[m
+# UTCTime
+[33m<string>[m

--- a/autodocodec-api-usage/test_resources/yaml-schema/zoned-time.txt
+++ b/autodocodec-api-usage/test_resources/yaml-schema/zoned-time.txt
@@ -1,2 +1,2 @@
 # ZonedTime
-[33m<any>[m
+[33m<string>[m

--- a/autodocodec-openapi3/src/Autodocodec/OpenAPI/Schema.hs
+++ b/autodocodec-openapi3/src/Autodocodec/OpenAPI/Schema.hs
@@ -173,7 +173,7 @@ declareNamedSchemaVia c' Proxy = evalStateT (go c') mempty
                 _schemaType = Just OpenApiObject
               }
           ]
-      OptionalKeyWithOmittedDefaultCodec key vs defaultValue mDoc -> goObject (OptionalKeyWithDefaultCodec key vs defaultValue mDoc)
+      OptionalKeyWithOmittedDefaultCodec key vs defaultValue mDoc -> goObject (optionalKeyWithDefaultCodec key vs defaultValue mDoc)
       PureCodec _ -> pure []
       EitherCodec u oc1 oc2 -> do
         s1s <- goObject oc1

--- a/autodocodec-schema/src/Autodocodec/Schema.hs
+++ b/autodocodec-schema/src/Autodocodec/Schema.hs
@@ -377,7 +377,7 @@ jsonSchemaVia = (`evalState` S.empty) . go
       OptionalKeyWithDefaultCodec k c mr mdoc -> do
         s <- go c
         pure $ ObjectKeySchema k (Optional (Just (toJSONVia c mr))) s mdoc
-      OptionalKeyWithOmittedDefaultCodec k c defaultValue mDoc -> goObject (OptionalKeyWithDefaultCodec k c defaultValue mDoc)
+      OptionalKeyWithOmittedDefaultCodec k c defaultValue mDoc -> goObject (optionalKeyWithDefaultCodec k c defaultValue mDoc)
       BimapCodec _ _ c -> goObject c
       EitherCodec u oc1 oc2 -> do
         os1 <- goObject oc1

--- a/autodocodec-swagger2/src/Autodocodec/Swagger/Schema.hs
+++ b/autodocodec-swagger2/src/Autodocodec/Swagger/Schema.hs
@@ -160,7 +160,7 @@ declareNamedSchemaVia c' Proxy = go c'
                     }
               }
           ]
-      OptionalKeyWithOmittedDefaultCodec key vs defaultValue mDoc -> goObject (OptionalKeyWithDefaultCodec key vs defaultValue mDoc)
+      OptionalKeyWithOmittedDefaultCodec key vs defaultValue mDoc -> goObject (optionalKeyWithDefaultCodec key vs defaultValue mDoc)
       PureCodec _ -> pure []
       EitherCodec u oc1 oc2 -> do
         ss1 <- goObject oc1

--- a/autodocodec/CHANGELOG.md
+++ b/autodocodec/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [0.3.0.0] - 2024-06-16
 
+### Added
+
+* HasCodec instances for Const, (), Dual, Semigroup.First, Semigroup.Last, Monoid.First and Monoid.Last
+
+### Fixed
+
+* Infinitely looping `Identity` instance
+
 ### Changed
 
 * Refactored `Codec` so it's input and output parameters have a representative, not nominal role.

--- a/autodocodec/CHANGELOG.md
+++ b/autodocodec/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.3.0.0] - 2024-06-16
+
+### Changed
+
+* Refactored `Codec` so it's input and output parameters have a representative, not nominal role.
+  This means one can now use `deriving newtype` with the `HasCodec` class.
+
 ## [0.2.3.0] - 2024-06-23
 
 ### Added

--- a/autodocodec/src/Autodocodec/Aeson/Decode.hs
+++ b/autodocodec/src/Autodocodec/Aeson/Decode.hs
@@ -25,9 +25,11 @@ import Autodocodec.DerivingVia
 import Control.Monad
 import Data.Aeson as JSON
 import Data.Aeson.Types as JSON
+import Data.Coerce (coerce)
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
 import Data.Map (Map)
+import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Vector (Vector)
 import qualified Data.Vector as V
@@ -59,34 +61,36 @@ parseJSONContextVia codec_ context_ =
     go :: context -> Codec context void a -> JSON.Parser a
     go value = \case
       NullCodec -> case (value :: JSON.Value) of
-        Null -> pure ()
+        Null -> coerce (pure () :: JSON.Parser ())
         _ -> typeMismatch "Null" value
       BoolCodec mname -> case mname of
-        Nothing -> parseJSON value
-        Just name -> withBool (T.unpack name) pure value
+        Nothing -> coerce (parseJSON value :: JSON.Parser Bool)
+        Just name -> coerce $ withBool (T.unpack name) pure value
       StringCodec mname -> case mname of
-        Nothing -> parseJSON value
-        Just name -> withText (T.unpack name) pure value
+        Nothing -> coerce (parseJSON value :: JSON.Parser Text)
+        Just name -> coerce $ withText (T.unpack name) pure value
       NumberCodec mname mBounds ->
-        ( \f -> case mname of
-            Nothing -> parseJSON value >>= f
-            Just name -> withScientific (T.unpack name) f value
-        )
-          ( \s -> case maybe Right checkNumberBounds mBounds s of
-              Left err -> fail err
-              Right s' -> pure s'
+        coerce $
+          ( \f -> case mname of
+              Nothing -> parseJSON value >>= f
+              Just name -> withScientific (T.unpack name) f value
           )
+            ( \s -> case maybe Right checkNumberBounds mBounds s of
+                Left err -> fail err
+                Right s' -> pure s'
+            )
       ArrayOfCodec mname c ->
         ( \f -> case mname of
             Nothing -> parseJSON value >>= f
             Just name -> withArray (T.unpack name) f value
         )
           ( \vector ->
-              forM
-                (V.indexed (vector :: Vector JSON.Value))
-                ( \(ix, v) ->
-                    go v c JSON.<?> Index ix
-                )
+              coerce $
+                forM
+                  (V.indexed (vector :: Vector JSON.Value))
+                  ( \(ix, v) ->
+                      go v c JSON.<?> Index ix
+                  )
           )
       ObjectOfCodec mname c ->
         ( \f -> case mname of
@@ -94,13 +98,13 @@ parseJSONContextVia codec_ context_ =
             Just name -> withObject (T.unpack name) f value
         )
           (\object_ -> (`go` c) (object_ :: JSON.Object))
-      HashMapCodec c -> Compat.liftParseJSON (`go` c) (`go` listCodec c) value :: JSON.Parser (HashMap _ _)
-      MapCodec c -> Compat.liftParseJSON (`go` c) (`go` listCodec c) value :: JSON.Parser (Map _ _)
-      ValueCodec -> pure (value :: JSON.Value)
+      HashMapCodec c -> coerce (Compat.liftParseJSON (`go` c) (`go` listCodec c) value :: JSON.Parser (HashMap _ _))
+      MapCodec c -> coerce (Compat.liftParseJSON (`go` c) (`go` listCodec c) value :: JSON.Parser (Map _ _))
+      ValueCodec -> pure $ coerce value
       EqCodec expected c -> do
         actual <- go value c
         if expected == actual
-          then pure actual
+          then pure (coerce actual)
           else fail $ unwords ["Expected", show expected, "but got", show actual]
       BimapCodec f _ c -> do
         old <- go value c
@@ -110,7 +114,7 @@ parseJSONContextVia codec_ context_ =
       EitherCodec u c1 c2 ->
         let leftParser v = Left <$> go v c1
             rightParser v = Right <$> go v c2
-         in case u of
+         in coerce $ case u of
               PossiblyJointUnion ->
                 case parseEither leftParser value of
                   Right l -> pure l
@@ -141,11 +145,11 @@ parseJSONContextVia codec_ context_ =
       OptionalKeyCodec k c _ -> do
         let key = Compat.toKey k
             mValueAtKey = Compat.lookupKey key (value :: JSON.Object)
-        forM mValueAtKey $ \valueAtKey -> go (valueAtKey :: JSON.Value) c JSON.<?> Key key
+        coerce $ forM mValueAtKey $ \valueAtKey -> go (valueAtKey :: JSON.Value) c JSON.<?> Key key
       OptionalKeyWithDefaultCodec k c defaultValue _ -> do
         let key = Compat.toKey k
             mValueAtKey = Compat.lookupKey key (value :: JSON.Object)
-        case mValueAtKey of
+        coerce $ case mValueAtKey of
           Nothing -> pure defaultValue
           Just valueAtKey -> go (valueAtKey :: JSON.Value) c JSON.<?> Key key
       OptionalKeyWithOmittedDefaultCodec k c defaultValue mDoc -> go value $ OptionalKeyWithDefaultCodec k c defaultValue mDoc

--- a/autodocodec/src/Autodocodec/Class.hs
+++ b/autodocodec/src/Autodocodec/Class.hs
@@ -172,21 +172,20 @@ instance HasCodec v => HasCodec (KeyMap v) where
   codec = keyMapCodec codec
 #endif
 
--- TODO make these instances better once aeson exposes its @Data.Aeson.Parser.Time@ or @Data.Attoparsec.Time@ modules.
 instance HasCodec Day where
-  codec = codecViaAeson "Day"
+  codec = unsafeCodecViaAesonString "Day"
 
 instance HasCodec LocalTime where
-  codec = codecViaAeson "LocalTime"
+  codec = unsafeCodecViaAesonString "LocalTime"
 
 instance HasCodec UTCTime where
-  codec = codecViaAeson "LocalTime"
+  codec = unsafeCodecViaAesonString "UTCTime"
 
 instance HasCodec TimeOfDay where
-  codec = codecViaAeson "TimeOfDay"
+  codec = unsafeCodecViaAesonString "TimeOfDay"
 
 instance HasCodec ZonedTime where
-  codec = codecViaAeson "ZonedTime"
+  codec = unsafeCodecViaAesonString "ZonedTime"
 
 instance HasCodec NominalDiffTime where
   codec = dimapCodec realToFrac realToFrac (codec :: JSONCodec Scientific)

--- a/autodocodec/src/Autodocodec/Class.hs
+++ b/autodocodec/src/Autodocodec/Class.hs
@@ -52,7 +52,7 @@ class HasCodec value where
   {-# MINIMAL codec #-}
 
 instance HasCodec Void where
-  codec = bimapCodec (\_ -> Left "Cannot decode a Void.") absurd ValueCodec
+  codec = bimapCodec (\_ -> Left "Cannot decode a Void.") absurd valueCodec
 
 instance HasCodec Bool where
   codec = boolCodec
@@ -117,7 +117,7 @@ instance HasCodec Natural where
   codec = naturalCodec
 
 instance HasCodec JSON.Value where
-  codec = ValueCodec
+  codec = valueCodec
 
 instance (HasCodec a) => HasCodec (Identity a) where
   codec = dimapCodec runIdentity Identity codec
@@ -144,10 +144,10 @@ instance (Ord a, HasCodec a) => HasCodec (Set a) where
   codec = dimapCodec S.fromList S.toList codec
 
 instance (Ord k, FromJSONKey k, ToJSONKey k, HasCodec v) => HasCodec (Map k v) where
-  codec = MapCodec codec
+  codec = mapCodec codec
 
 instance (Eq k, Hashable k, FromJSONKey k, ToJSONKey k, HasCodec v) => HasCodec (HashMap k v) where
-  codec = HashMapCodec codec
+  codec = hashMapCodec codec
 
 #if MIN_VERSION_aeson(2,0,0)
 instance HasCodec v => HasCodec (KeyMap v) where
@@ -276,7 +276,7 @@ optionalFieldOrNull ::
   -- | Documentation
   Text ->
   ObjectCodec (Maybe output) (Maybe output)
-optionalFieldOrNull key doc = orNullHelper $ OptionalKeyCodec key (maybeCodec codec) (Just doc)
+optionalFieldOrNull key doc = orNullHelper $ optionalKeyCodec key (maybeCodec codec) (Just doc)
 
 -- | Like 'optionalFieldOrNull', but without documentation
 optionalFieldOrNull' ::
@@ -285,7 +285,7 @@ optionalFieldOrNull' ::
   -- | Key
   Text ->
   ObjectCodec (Maybe output) (Maybe output)
-optionalFieldOrNull' key = orNullHelper $ OptionalKeyCodec key (maybeCodec codec) Nothing
+optionalFieldOrNull' key = orNullHelper $ optionalKeyCodec key (maybeCodec codec) Nothing
 
 optionalFieldWithOmittedDefault ::
   (Eq output, HasCodec output) =>

--- a/autodocodec/src/Autodocodec/Class.hs
+++ b/autodocodec/src/Autodocodec/Class.hs
@@ -1,9 +1,12 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedLists #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 -- Because Eq is a superclass of Hashable in newer versions.
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
@@ -16,13 +19,17 @@ import Numeric.Natural
 #if MIN_VERSION_aeson(2,0,0)
 import Data.Aeson.KeyMap (KeyMap)
 #endif
+import Data.Functor.Const (Const (Const))
 import Data.Functor.Identity
 import Data.HashMap.Strict (HashMap)
 import Data.Hashable (Hashable)
 import Data.Int
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Map (Map)
+import qualified Data.Monoid as Monoid
 import Data.Scientific
+import Data.Semigroup (Dual (Dual))
+import qualified Data.Semigroup as Semigroup
 import Data.Set (Set)
 import qualified Data.Set as S
 import Data.Text (Text)
@@ -119,8 +126,19 @@ instance HasCodec Natural where
 instance HasCodec JSON.Value where
   codec = valueCodec
 
-instance (HasCodec a) => HasCodec (Identity a) where
-  codec = dimapCodec runIdentity Identity codec
+deriving newtype instance (HasCodec a) => HasCodec (Identity a)
+
+deriving newtype instance (HasCodec a) => HasCodec (Dual a)
+
+deriving newtype instance (HasCodec a) => HasCodec (Semigroup.First a)
+
+deriving newtype instance (HasCodec a) => HasCodec (Semigroup.Last a)
+
+deriving newtype instance (HasCodec a) => HasCodec (Monoid.First a)
+
+deriving newtype instance (HasCodec a) => HasCodec (Monoid.Last a)
+
+deriving newtype instance (HasCodec a) => HasCodec (Const a b)
 
 instance (HasCodec a) => HasCodec (Maybe a) where
   codec = maybeCodec codec

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,7 +11,7 @@ packages:
 
 extra-deps:
 - github: NorfairKing/validity
-  commit: 57c4897ccfeb3de60489e0328113798f059ef140
+  commit: 6b06ec70bdd999f7450f88f4beea43f1607e3726
   subdirs:
     - validity
     - validity-aeson


### PR DESCRIPTION
I'm just making this PR to keep you up to date with a fork of `autodocodec` I'm maintaining.

I know I submitted some previous PRs without tests (https://github.com/NorfairKing/autodocodec/pull/44) and never got around to adding those tests, so sorry for being slack about this.

Unfortunately the situation isn't much better with this PR, except now I've significantly changed the definition of the `Codec` class, to make it's parameters of representation role, which means `HasCodec` can now be newtyped derived (and also `Codec` can be `coerce`d). 

This brings `HasCodec` in line with classes like `ToJSON`, `FromJSON` and `ToSchema`, which can be newtype derived.

The downside to this is lots of new `Coercible` constraints in the definition of `Codec` and a bunch of new calls to `coerce`. 

I understand this is a controversial change which you may not want to accept, it does complicate the code for main benefit of being able to use `deriving newtype HasCodec` instead of:

```
instance HasCodec T where
  codec = dimapCodec T fromT codec
```

But I've got so many newtypes in my application this convenience was worth it to me. 

But I thought it best to at least keep you up to date with the changes I'm making, you may want to merge at least some of them.

I will try to get around to adding tests for the new instances also (although with this change, the new instances are actually just newtype derived, so perhaps the tests are less needed). But I don't think I'll get around to that for at least a month or so. 