### PR TITLE
Non-orphan openapi and swagger instances

### DIFF
--- a/autodocodec-api-usage/src/Autodocodec/Usage.hs
+++ b/autodocodec-api-usage/src/Autodocodec/Usage.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -18,7 +19,9 @@ import Autodocodec
 import Autodocodec.Aeson ()
 import Autodocodec.Multipart
 import Autodocodec.OpenAPI ()
+import Autodocodec.OpenAPI.DerivingVia.NonOrphan (AutodocodecOpenApi)
 import Autodocodec.Swagger ()
+import Autodocodec.Swagger.DerivingVia.NonOrphan (AutodocodecSwagger)
 import Control.Applicative
 import Control.DeepSeq
 import Data.Aeson (FromJSON (..), ToJSON (..))
@@ -729,3 +732,9 @@ monoidLastCodec = codec
 
 constCodec :: (HasCodec a) => JSONCodec (Const a b)
 constCodec = codec
+
+-- Using the non-orphan instances for 'OpenAPI' and 'Swagger' 'ToSchema' instances
+newtype NonOrphanExample = NonOrphanExample Example
+  deriving newtype (HasCodec)
+  deriving (OpenAPI.ToSchema) via (AutodocodecOpenApi NonOrphanExample)
+  deriving (Swagger.ToSchema) via (AutodocodecSwagger NonOrphanExample)

--- a/autodocodec-openapi3/autodocodec-openapi3.cabal
+++ b/autodocodec-openapi3/autodocodec-openapi3.cabal
@@ -27,6 +27,7 @@ library
   exposed-modules:
       Autodocodec.OpenAPI
       Autodocodec.OpenAPI.DerivingVia
+      Autodocodec.OpenAPI.DerivingVia.NonOrphan
       Autodocodec.OpenAPI.Schema
   other-modules:
       Paths_autodocodec_openapi3

--- a/autodocodec-openapi3/src/Autodocodec/OpenAPI/DerivingVia.hs
+++ b/autodocodec-openapi3/src/Autodocodec/OpenAPI/DerivingVia.hs
@@ -3,14 +3,24 @@
 
 module Autodocodec.OpenAPI.DerivingVia where
 
-import Autodocodec
-import Autodocodec.OpenAPI.Schema
-import Data.OpenApi as OpenAPI
-import Data.Proxy
-import Data.Typeable
+import Autodocodec (Autodocodec, HasCodec)
+import Autodocodec.OpenAPI.Schema (declareNamedSchemaViaCodec)
+import qualified Data.OpenApi as OpenAPI
+import Data.Proxy (Proxy (Proxy))
+import Data.Typeable (Typeable)
 
 -- | An instance for 'Autodocodec' that lets you use 'DerivingVia' to derive 'OpenAPI.ToSchema' if your type has a 'HasCodec' instance.
 --
 -- > deriving (OpenAPI.ToSchema) via (Autodocodec FooBar)
 instance (Typeable a, HasCodec a) => OpenAPI.ToSchema (Autodocodec a) where
-  declareNamedSchema (Proxy :: Proxy (Autodocodec a)) = declareNamedSchemaViaCodec (Proxy :: Proxy a)
+  -- This is declared like this as because now 'declareNamedSchema' takes no arguments, it can be memoized (like a top level variable is).
+  -- As a result, the result of the 'let', that is the schema, should also be memoized,
+  -- so with this definition schema in 'declaredNamedSchema' should only need to be calculated once IF the instance is of the form:
+  -- > deriving (OpenAPI.ToSchema) via (Autodocodec FooBar)
+  -- where FooBar is a concrete type.
+  -- If the instance is of the form:
+  -- > deriving via (Autodocodec (FooBar a)) instance (OpenAPI.ToSchema (FooBar a))
+  -- this memoisation trick probably won't work (as 'declaredNamedSchema' actually is a function due to hiddent typeclass dictionary arguments)
+  -- but it shouldn't hurt to try. See:
+  -- https://stackoverflow.com/questions/77056264/caching-an-expensive-to-compute-result-in-a-class-instance
+  declareNamedSchema = let schema = declareNamedSchemaViaCodec (Proxy :: Proxy a) in const schema

--- a/autodocodec-openapi3/src/Autodocodec/OpenAPI/DerivingVia/NonOrphan.hs
+++ b/autodocodec-openapi3/src/Autodocodec/OpenAPI/DerivingVia/NonOrphan.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Autodocodec.OpenAPI.DerivingVia.NonOrphan where
+
+import Autodocodec.Class (HasCodec)
+import Autodocodec.OpenAPI.Schema (declareNamedSchemaViaCodec)
+import qualified Data.OpenApi as OpenAPI
+import Data.Proxy (Proxy (Proxy))
+import Data.Typeable (Typeable)
+
+newtype AutodocodecOpenApi a = AutodocodecOpenApi {unAutodocodecSwagger :: a}
+
+-- | An instance for 'Autodocodec' that lets you use 'DerivingVia' to derive 'OpenAPI.ToSchema' if your type has a 'HasCodec' instance.
+--
+-- > deriving (OpenAPI.ToSchema) via (Autodocodec FooBar)
+instance (Typeable a, HasCodec a) => OpenAPI.ToSchema (AutodocodecOpenApi a) where
+  -- See comments in 'Autodocodec.OpenAPI.DerivingVia' for the reason why this is defined like this.
+  declareNamedSchema = let schema = declareNamedSchemaViaCodec (Proxy :: Proxy a) in const schema

--- a/autodocodec-swagger2/autodocodec-swagger2.cabal
+++ b/autodocodec-swagger2/autodocodec-swagger2.cabal
@@ -27,6 +27,7 @@ library
   exposed-modules:
       Autodocodec.Swagger
       Autodocodec.Swagger.DerivingVia
+      Autodocodec.Swagger.DerivingVia.NonOrphan
       Autodocodec.Swagger.Schema
   other-modules:
       Paths_autodocodec_swagger2

--- a/autodocodec-swagger2/src/Autodocodec/Swagger/DerivingVia.hs
+++ b/autodocodec-swagger2/src/Autodocodec/Swagger/DerivingVia.hs
@@ -3,13 +3,14 @@
 
 module Autodocodec.Swagger.DerivingVia where
 
-import Autodocodec
-import Autodocodec.Swagger.Schema
-import Data.Proxy
-import Data.Swagger as Swagger
+import Autodocodec (Autodocodec, HasCodec)
+import Autodocodec.Swagger.Schema (declareNamedSchemaViaCodec)
+import Data.Proxy (Proxy (..))
+import qualified Data.Swagger as Swagger
 
 -- | An instance for 'Autodocodec' that lets you use 'DerivingVia' to derive 'Swagger.ToSchema' if your type has a 'HasCodec' instance.
 --
 -- > deriving (Swagger.ToSchema) via (Autodocodec FooBar)
 instance (HasCodec a) => Swagger.ToSchema (Autodocodec a) where
-  declareNamedSchema (Proxy :: Proxy (Autodocodec a)) = declareNamedSchemaViaCodec (Proxy :: Proxy a)
+  -- See comments in 'Autodocodec.OpenAPI.DerivingVia' for the reason why this is defined like this.
+  declareNamedSchema = let schema = declareNamedSchemaViaCodec (Proxy :: Proxy a) in const schema

--- a/autodocodec-swagger2/src/Autodocodec/Swagger/DerivingVia/NonOrphan.hs
+++ b/autodocodec-swagger2/src/Autodocodec/Swagger/DerivingVia/NonOrphan.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Autodocodec.Swagger.DerivingVia.NonOrphan (AutodocodecSwagger (..)) where
+
+import Autodocodec (HasCodec)
+import Autodocodec.Swagger.Schema (declareNamedSchemaViaCodec)
+import Data.Proxy (Proxy (..))
+import qualified Data.Swagger as Swagger
+
+newtype AutodocodecSwagger a = AutodocodecSwagger {unAutodocodecSwagger :: a}
+
+-- | An non-orphan instance for 'AutodocodecSwagger' that lets you use 'DerivingVia' to derive 'Swagger.ToSchema' if your type has a 'HasCodec' instance.
+--
+-- > deriving (Swagger.ToSchema) via (AutodocodecSwagger FooBar)
+instance (HasCodec a) => Swagger.ToSchema (AutodocodecSwagger a) where
+  -- See comments in 'Autodocodec.OpenAPI.DerivingVia' for the reason why this is defined like this.
+  declareNamedSchema = let schema = declareNamedSchemaViaCodec (Proxy :: Proxy a) in const schema


### PR DESCRIPTION
A while back, I was very confused when I was getting an error from the following code:

```
data FooBar = ...
  deriving (ToJSON, FromJSON, ToSchema) via (Autodocodec FooBar)

instance HasCodec Blah where ...
```

Everything seemed imported, but the issue is that the `ToSchema` instance in `autodocodec-swagger2`/`autodocodec-openapi3` is orphan.

So then I'd have to explicitly add:

```
import Autodocodec.Swagger.DerivingVia ()
```

And my editor didn't help me with this. 

I get why these instances are orphan, because we don't want to define these instances in the `autodocodec` library proper, next to the `Autodocodec` type, as that will mean Autodocodec gets all the dependencies of `swagger2`/`openapi3`.

So instead I made a little newtype, and now I can derive Swagger/OpenApi instances like so:

```
data FooBar = ...
  deriving (ToJSON, FromJSON) via (Autodocodec FooBar)
  deriving (ToSchema) via (AutodocodecOpenAPI FooBar)
```

A little bit longer, but my editor nicely completes all the required imports.

Also these instances are not orphans, so you don't get [this slowdown in compilation](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/separate_compilation.html#orphan-modules-and-instance-declarations).

Not sure how significant it is, but we can avoid the orphans here. In any case this isn't really about compilation speed, I just find the non-orphan approach has less gotchas (namely, avoiding confusing messages about an expected instance not existing). Note I've left the existing approach for backwards compatibility, but GHC won't see the orphan instance unless it's directly or indirectly important, which won't be the case for anyone who imports `Autodocodec.OpenAPI.DerivingVia.NonOrphan` directly.

The other thing I've done as a side quest is slightly changed the instance definitions so that repeated calls to `declareNamedSchema` are less likely to result in recomputation. See the comments in `Autodocodec.OpenAPI.DerivingVia`. Note this _may_ slightly increase memory usage as GHC will be less keen to garbage collect any schemas created by `declareNamedSchema`, but I think this will be minimal, GHC will only allocated to memory for one schema per instance declaration in the source code, and indeed may instance declarations will not be cached in the case the type still has any free parameters.