### PR TITLE
Remove all orphans

### DIFF
--- a/autodocodec-api-usage/test/Autodocodec/NixSpec.hs
+++ b/autodocodec-api-usage/test/Autodocodec/NixSpec.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Autodocodec.NixSpec (spec) where
 

--- a/autodocodec-api-usage/test/Autodocodec/OpenAPISpec.hs
+++ b/autodocodec-api-usage/test/Autodocodec/OpenAPISpec.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Autodocodec.OpenAPISpec (spec) where
 

--- a/autodocodec-api-usage/test/Autodocodec/SwaggerSpec.hs
+++ b/autodocodec-api-usage/test/Autodocodec/SwaggerSpec.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Autodocodec.SwaggerSpec (spec) where
 

--- a/autodocodec-openapi3/src/Autodocodec/OpenAPI/Schema.hs
+++ b/autodocodec-openapi3/src/Autodocodec/OpenAPI/Schema.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Autodocodec.OpenAPI.Schema where
 

--- a/autodocodec-swagger2/src/Autodocodec/Swagger/Schema.hs
+++ b/autodocodec-swagger2/src/Autodocodec/Swagger/Schema.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Autodocodec.Swagger.Schema where
 

--- a/autodocodec-yaml/CHANGELOG.md
+++ b/autodocodec-yaml/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Changelog
 
-## [0.3.0.1] - 2024-07-26
+## [0.4.0.0] - 2024-08-03
 
+### Changed
+
+* Remove orphan `ToYaml (Autodocodec a)` instance, instead defining a `AutodocodecYaml` newtype 
+  and replacing the instance with a non-orphan `ToYaml (AutodocodecYaml a)` instance.
+
+## [0.3.0.1] - 2024-07-26
 
 * Support for `autodocodec >=0.4` and `autodocodec-schema >=0.2`.
 

--- a/autodocodec-yaml/autodocodec-yaml.cabal
+++ b/autodocodec-yaml/autodocodec-yaml.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           autodocodec-yaml
-version:        0.3.0.2
+version:        0.4.0.0
 synopsis:       Autodocodec interpreters for yaml
 homepage:       https://github.com/NorfairKing/autodocodec#readme
 bug-reports:    https://github.com/NorfairKing/autodocodec/issues

--- a/autodocodec-yaml/default.nix
+++ b/autodocodec-yaml/default.nix
@@ -4,7 +4,7 @@
 }:
 mkDerivation {
   pname = "autodocodec-yaml";
-  version = "0.3.0.2";
+  version = "0.4.0.0";
   src = ./.;
   libraryHaskellDepends = [
     autodocodec autodocodec-schema base bytestring containers path

--- a/autodocodec-yaml/package.yaml
+++ b/autodocodec-yaml/package.yaml
@@ -1,5 +1,5 @@
 name: autodocodec-yaml
-version: 0.3.0.2
+version: 0.4.0.0
 github: "NorfairKing/autodocodec"
 license: MIT
 author: "Tom Sydney Kerckhove"

--- a/autodocodec-yaml/src/Autodocodec/Yaml.hs
+++ b/autodocodec-yaml/src/Autodocodec/Yaml.hs
@@ -40,7 +40,7 @@ import qualified Data.Yaml.Builder as Yaml
 
 -- | Encode a value as a Yaml 'ByteString' via its type's 'codec'.
 encodeYamlViaCodec :: (HasCodec a) => a -> ByteString
-encodeYamlViaCodec = Yaml.toByteString . Autodocodec
+encodeYamlViaCodec = Yaml.toByteString . AutodocodecYaml
 
 -- | Parse a Yaml 'ByteString' using a type's 'codec'.
 eitherDecodeYamlViaCodec :: (HasCodec a) => ByteString -> Either Yaml.ParseException a

--- a/autodocodec-yaml/src/Autodocodec/Yaml/Encode.hs
+++ b/autodocodec-yaml/src/Autodocodec/Yaml/Encode.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PartialTypeSignatures #-}
-{-# OPTIONS_GHC -fno-warn-partial-type-signatures -fno-warn-orphans #-}
+{-# OPTIONS_GHC -fno-warn-partial-type-signatures #-}
 
 module Autodocodec.Yaml.Encode where
 
@@ -10,7 +10,6 @@ import qualified Autodocodec.Aeson.Compat as Compat
 import Autodocodec.Aeson.Encode
 import Autodocodec.Class
 import Autodocodec.Codec
-import Autodocodec.DerivingVia
 import Control.Arrow (first)
 import Data.Coerce (coerce)
 import Data.Scientific
@@ -94,5 +93,7 @@ toYamlVia = flip go
       JSON.Object o -> yamlObject o
       JSON.Array v -> Yaml.array $ map yamlValue $ V.toList v
 
-instance (HasCodec a) => ToYaml (Autodocodec a) where
-  toYaml = toYamlViaCodec . unAutodocodec
+newtype AutodocodecYaml a = AutodocodecYaml {unAutodocodecYaml :: a}
+
+instance (HasCodec a) => ToYaml (AutodocodecYaml a) where
+  toYaml = toYamlViaCodec . unAutodocodecYaml

--- a/autodocodec/CHANGELOG.md
+++ b/autodocodec/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.4.1.0] - 2024-08-03
+
+### Changed
+
+* Moved the `ToJSON (Autodocodec a)` and `FromJSON (Autodocodec a)` instances so they are no longer orphans.
+
 ## [0.4.0.0] - 2024-07-26
 
 This is technically a breaking change but it's unlikely that you'll need to

--- a/autodocodec/autodocodec.cabal
+++ b/autodocodec/autodocodec.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           autodocodec
-version:        0.4.0.0
+version:        0.4.1.0
 synopsis:       Self-documenting encoder and decoder
 homepage:       https://github.com/NorfairKing/autodocodec#readme
 bug-reports:    https://github.com/NorfairKing/autodocodec/issues

--- a/autodocodec/default.nix
+++ b/autodocodec/default.nix
@@ -4,7 +4,7 @@
 }:
 mkDerivation {
   pname = "autodocodec";
-  version = "0.4.0.0";
+  version = "0.4.1.0";
   src = ./.;
   libraryHaskellDepends = [
     aeson base bytestring containers hashable mtl scientific text time

--- a/autodocodec/package.yaml
+++ b/autodocodec/package.yaml
@@ -1,5 +1,5 @@
 name: autodocodec
-version: 0.4.0.0
+version: 0.4.1.0
 github: "NorfairKing/autodocodec"
 license: MIT
 author: "Tom Sydney Kerckhove"

--- a/autodocodec/src/Autodocodec/Aeson/Decode.hs
+++ b/autodocodec/src/Autodocodec/Aeson/Decode.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PartialTypeSignatures #-}
-{-# OPTIONS_GHC -fno-warn-partial-type-signatures -fno-warn-orphans #-}
+{-# OPTIONS_GHC -fno-warn-partial-type-signatures #-}
 
 module Autodocodec.Aeson.Decode
   ( -- * Decoding JSON Values
@@ -21,7 +21,6 @@ where
 import qualified Autodocodec.Aeson.Compat as Compat
 import Autodocodec.Class
 import Autodocodec.Codec
-import Autodocodec.DerivingVia
 import Control.Monad
 import Data.Aeson as JSON
 import Data.Aeson.Types as JSON
@@ -179,6 +178,3 @@ parseJSONContextVia codec_ context_ =
       OptionalKeyWithOmittedDefaultCodec k c defaultValue mDoc -> go value $ OptionalKeyWithDefaultCodec k c defaultValue mDoc
       PureCodec a -> pure a
       ApCodec ocf oca -> go (value :: JSON.Object) ocf <*> go (value :: JSON.Object) oca
-
-instance (HasCodec a) => JSON.FromJSON (Autodocodec a) where
-  parseJSON = fmap Autodocodec <$> parseJSONViaCodec

--- a/autodocodec/src/Autodocodec/Aeson/Encode.hs
+++ b/autodocodec/src/Autodocodec/Aeson/Encode.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE PartialTypeSignatures #-}
-{-# OPTIONS_GHC -fno-warn-partial-type-signatures -fno-warn-orphans #-}
+{-# OPTIONS_GHC -fno-warn-partial-type-signatures #-}
 
 module Autodocodec.Aeson.Encode
   ( -- * Encoding JSON Values
@@ -21,7 +21,6 @@ where
 import qualified Autodocodec.Aeson.Compat as Compat
 import Autodocodec.Class
 import Autodocodec.Codec
-import Autodocodec.DerivingVia
 import Data.Aeson (toJSON)
 import qualified Data.Aeson as JSON
 import qualified Data.Aeson.Encoding as JSON
@@ -146,7 +145,3 @@ toEncodingVia = flip go
         Right a2 -> go a2 c2
       CommentCodec _ c -> go a c
       ReferenceCodec _ c -> go a c
-
-instance (HasCodec a) => JSON.ToJSON (Autodocodec a) where
-  toJSON = toJSONViaCodec . unAutodocodec
-  toEncoding = toEncodingViaCodec . unAutodocodec

--- a/autodocodec/src/Autodocodec/DerivingVia.hs
+++ b/autodocodec/src/Autodocodec/DerivingVia.hs
@@ -1,5 +1,10 @@
 module Autodocodec.DerivingVia where
 
+import Autodocodec.Aeson.Decode (parseJSONViaCodec)
+import Autodocodec.Aeson.Encode (toEncodingViaCodec, toJSONViaCodec)
+import Autodocodec.Class (HasCodec)
+import qualified Data.Aeson as JSON
+
 -- | 'Autodocodec' is a wrapper to provide codec-based deriving strategies.
 --
 -- === Example usage
@@ -15,3 +20,10 @@ module Autodocodec.DerivingVia where
 -- >         <$> requiredField "one" "first field" .= viaOne
 -- >         <*> requiredField "two" "second field" .= viaTwo
 newtype Autodocodec a = Autodocodec {unAutodocodec :: a}
+
+instance (HasCodec a) => JSON.ToJSON (Autodocodec a) where
+  toJSON = toJSONViaCodec . unAutodocodec
+  toEncoding = toEncodingViaCodec . unAutodocodec
+
+instance (HasCodec a) => JSON.FromJSON (Autodocodec a) where
+  parseJSON = fmap Autodocodec <$> parseJSONViaCodec


### PR DESCRIPTION
The `ToJSON` and `FromJSON` instances were unnecessarily orphans, there's no need for them to be.

Whilst I was there I also applied the same pattern to the `ToYaml` instance that has been similarly applied to `ToSchema` instances for OpenAPI and Swagger, namely defining a newtype in the file instead of using `Autodocodec` type defined in a different library. 