### PR TITLE
Hack to fix discriminated union OpenAPI schema generation

### DIFF
--- a/autodocodec-api-usage/test_resources/openapi-schema/declareSchemaRef/expression.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/declareSchemaRef/expression.json
@@ -3,9 +3,9 @@
         "Expression": {
             "discriminator": {
                 "mapping": {
-                    "literal": "LiteralExpression",
-                    "product": "ProductExpression",
-                    "sum": "SumExpression"
+                    "literal": "#/components/schemas/LiteralExpression",
+                    "product": "#/components/schemas/ProductExpression",
+                    "sum": "#/components/schemas/SumExpression"
                 },
                 "propertyName": "type"
             },

--- a/autodocodec-api-usage/test_resources/openapi-schema/declareSchemaRef/these.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/declareSchemaRef/these.json
@@ -47,9 +47,9 @@
         "These": {
             "discriminator": {
                 "mapping": {
-                    "both": "Both",
-                    "that": "That",
-                    "this": "This"
+                    "both": "#/components/schemas/Both",
+                    "that": "#/components/schemas/That",
+                    "this": "#/components/schemas/This"
                 },
                 "propertyName": "type"
             },

--- a/autodocodec-api-usage/test_resources/openapi-schema/expression.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/expression.json
@@ -4,9 +4,9 @@
             "Expression": {
                 "discriminator": {
                     "mapping": {
-                        "literal": "LiteralExpression",
-                        "product": "ProductExpression",
-                        "sum": "SumExpression"
+                        "literal": "#/components/schemas/LiteralExpression",
+                        "product": "#/components/schemas/ProductExpression",
+                        "sum": "#/components/schemas/SumExpression"
                     },
                     "propertyName": "type"
                 },

--- a/autodocodec-api-usage/test_resources/openapi-schema/these.json
+++ b/autodocodec-api-usage/test_resources/openapi-schema/these.json
@@ -48,9 +48,9 @@
             "These": {
                 "discriminator": {
                     "mapping": {
-                        "both": "Both",
-                        "that": "That",
-                        "this": "This"
+                        "both": "#/components/schemas/Both",
+                        "that": "#/components/schemas/That",
+                        "this": "#/components/schemas/This"
                     },
                     "propertyName": "type"
                 },

--- a/autodocodec-openapi3/src/Autodocodec/OpenAPI/Schema.hs
+++ b/autodocodec-openapi3/src/Autodocodec/OpenAPI/Schema.hs
@@ -194,7 +194,7 @@ declareNamedSchemaVia c' Proxy = evalStateT (go c') mempty
         let d =
               Discriminator
                 { _discriminatorPropertyName = pn,
-                  _discriminatorMapping = InsOrdHashMap.fromHashMap $ fmap fst m
+                  _discriminatorMapping = InsOrdHashMap.fromHashMap $ fmap (\x -> "#/components/schemas/" <> fst x) m
                 }
             mkSchema dName (refName, oc) = do
               s <- goObject $ oc *> (requiredFieldWith' pn (literalTextCodec dName) .= const dName)


### PR DESCRIPTION
I've found what I'm pretty sure is a bug in the OpenAPI JSON generation. 

The hack in this PR fixes the bug, although I suspect it's not the best way to do the fix. I've pushed it up for illustrative purposes. 

I think there's a bug (and this is somewhat in the right direction of a fix) because when you see the example here:

https://swagger.io/docs/specification/v3_0/data-models/inheritance-and-polymorphism/#mapping-type-names

the `"oneOf:"` and `"discriminator:"` values need to match exactly.

I've also tested this with [`swagger-typescript-api`](https://www.npmjs.com/package/swagger-typescript-api). Before this "fix" the types inside the union are `"any"`. After the hack they are correctly typed.