### PR TITLE
Support min/max-length bounds for strings.

### DIFF
--- a/autodocodec-api-usage/autodocodec-api-usage.cabal
+++ b/autodocodec-api-usage/autodocodec-api-usage.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           autodocodec-api-usage
-version:        0.0.0.0
+version:        0.0.0.1
 synopsis:       Autodocodec api usage tests
 homepage:       https://github.com/NorfairKing/autodocodec#readme
 bug-reports:    https://github.com/NorfairKing/autodocodec/issues
@@ -507,7 +507,7 @@ library
   build-depends:
       QuickCheck
     , aeson
-    , autodocodec >=0.2.0.0
+    , autodocodec >=0.6.0.0
     , autodocodec-openapi3
     , autodocodec-schema
     , autodocodec-servant-multipart

--- a/autodocodec-api-usage/default.nix
+++ b/autodocodec-api-usage/default.nix
@@ -13,7 +13,7 @@
 }:
 mkDerivation {
   pname = "autodocodec-api-usage";
-  version = "0.0.0.0";
+  version = "0.0.0.1";
   src = ./.;
   libraryHaskellDepends = [
     aeson autodocodec autodocodec-openapi3 autodocodec-schema

--- a/autodocodec-api-usage/package.yaml
+++ b/autodocodec-api-usage/package.yaml
@@ -1,5 +1,5 @@
 name: autodocodec-api-usage
-version: 0.0.0.0
+version: 0.0.0.1
 github: "NorfairKing/autodocodec"
 license: MIT
 author: "Tom Sydney Kerckhove"
@@ -19,7 +19,7 @@ library:
   dependencies:
   - QuickCheck
   - aeson
-  - autodocodec >=0.2.0.0
+  - autodocodec >=0.6.0.0
   - autodocodec-openapi3
   - autodocodec-schema
   - autodocodec-servant-multipart

--- a/autodocodec-api-usage/test/Autodocodec/Aeson/SchemaSpec.hs
+++ b/autodocodec-api-usage/test/Autodocodec/Aeson/SchemaSpec.hs
@@ -143,7 +143,7 @@ instance GenValid JSONSchema where
     AnySchema -> []
     NullSchema -> [AnySchema]
     BoolSchema -> [AnySchema]
-    StringSchema -> [AnySchema]
+    StringSchema mBounds -> AnySchema : (StringSchema <$> shrinkValid mBounds)
     IntegerSchema mBounds -> AnySchema : (IntegerSchema <$> shrinkValid mBounds)
     NumberSchema mBounds -> AnySchema : (NumberSchema <$> shrinkValid mBounds)
     MapSchema s -> AnySchema : s : (MapSchema <$> shrinkValid s)
@@ -163,10 +163,11 @@ instance GenValid JSONSchema where
       pure $ WithDefSchema name' s'
   genValid = sized $ \n ->
     if n <= 1
-      then elements [AnySchema, NullSchema, BoolSchema, StringSchema]
+      then elements [AnySchema, NullSchema, BoolSchema]
       else
         oneof
           [ IntegerSchema <$> genValid,
+            StringSchema <$> genValid,
             NumberSchema <$> genValid,
             ArraySchema <$> resize (n - 1) genValid,
             MapSchema <$> resize (n - 1) genValid,
@@ -215,6 +216,10 @@ instance GenValid ObjectSchema where
           ]
 
 instance (GenValid a) => GenValid (Bounds a) where
+  genValid = genValidStructurallyWithoutExtraChecking
+  shrinkValid = shrinkValidStructurallyWithoutExtraFiltering
+
+instance GenValid StringBounds where
   genValid = genValidStructurallyWithoutExtraChecking
   shrinkValid = shrinkValidStructurallyWithoutExtraFiltering
 

--- a/autodocodec-api-usage/test_resources/show-codec/ainur.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/ainur.txt
@@ -12,13 +12,32 @@ BimapCodec
               (RequiredKeyCodec
                  "domain"
                  (Just "Domain which the Valar rules over")
-                 (StringCodec Nothing)))
+                 (StringCodec
+                    Nothing
+                    StringBounds
+                      { stringBoundsMinLength = Nothing
+                      , stringBoundsMaxLength = Nothing
+                      })))
            (BimapCodec
               _
               _
               (RequiredKeyCodec
-                 "name" (Just "Name of the Valar") (StringCodec Nothing)))))
+                 "name"
+                 (Just "Name of the Valar")
+                 (StringCodec
+                    Nothing
+                    StringBounds
+                      { stringBoundsMinLength = Nothing
+                      , stringBoundsMaxLength = Nothing
+                      })))))
      (ObjectOfCodec
         (Just "Maiar")
         (RequiredKeyCodec
-           "name" (Just "Name of the Maiar") (StringCodec Nothing))))
+           "name"
+           (Just "Name of the Maiar")
+           (StringCodec
+              Nothing
+              StringBounds
+                { stringBoundsMinLength = Nothing
+                , stringBoundsMaxLength = Nothing
+                }))))

--- a/autodocodec-api-usage/test_resources/show-codec/char.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/char.txt
@@ -1,1 +1,9 @@
-BimapCodec _ _ (StringCodec Nothing)
+BimapCodec
+  _
+  _
+  (StringCodec
+     Nothing
+     StringBounds
+       { stringBoundsMinLength = Nothing
+       , stringBoundsMaxLength = Nothing
+       })

--- a/autodocodec-api-usage/test_resources/show-codec/const.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/const.txt
@@ -1,1 +1,6 @@
-StringCodec Nothing
+StringCodec
+  Nothing
+  StringBounds
+    { stringBoundsMinLength = Nothing
+    , stringBoundsMaxLength = Nothing
+    }

--- a/autodocodec-api-usage/test_resources/show-codec/day.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/day.txt
@@ -1,1 +1,11 @@
-CommentCodec "Day" (BimapCodec _ _ (StringCodec Nothing))
+CommentCodec
+  "Day"
+  (BimapCodec
+     _
+     _
+     (StringCodec
+        Nothing
+        StringBounds
+          { stringBoundsMinLength = Nothing
+          , stringBoundsMaxLength = Nothing
+          }))

--- a/autodocodec-api-usage/test_resources/show-codec/derived.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/derived.txt
@@ -12,7 +12,15 @@ ObjectOfCodec
                              (BimapCodec
                                 _
                                 _
-                                (RequiredKeyCodec "text" (Just "a text") (StringCodec Nothing)))
+                                (RequiredKeyCodec
+                                   "text"
+                                   (Just "a text")
+                                   (StringCodec
+                                      Nothing
+                                      StringBounds
+                                        { stringBoundsMinLength = Nothing
+                                        , stringBoundsMaxLength = Nothing
+                                        })))
                              (BimapCodec
                                 _ _ (RequiredKeyCodec "bool" (Just "a bool") (BoolCodec Nothing))))
                           (BimapCodec
@@ -25,12 +33,26 @@ ObjectOfCodec
                                    _
                                    _
                                    (EitherCodec
-                                      PossiblyJointUnion NullCodec (StringCodec Nothing))))))
+                                      PossiblyJointUnion
+                                      NullCodec
+                                      (StringCodec
+                                         Nothing
+                                         StringBounds
+                                           { stringBoundsMinLength = Nothing
+                                           , stringBoundsMaxLength = Nothing
+                                           }))))))
                        (BimapCodec
                           _
                           _
                           (OptionalKeyCodec
-                             "optional" (Just "an optional text") (StringCodec Nothing))))
+                             "optional"
+                             (Just "an optional text")
+                             (StringCodec
+                                Nothing
+                                StringBounds
+                                  { stringBoundsMinLength = Nothing
+                                  , stringBoundsMaxLength = Nothing
+                                  }))))
                     (BimapCodec
                        _
                        _
@@ -41,13 +63,25 @@ ObjectOfCodec
                              _
                              _
                              (EitherCodec
-                                PossiblyJointUnion NullCodec (StringCodec Nothing))))))
+                                PossiblyJointUnion
+                                NullCodec
+                                (StringCodec
+                                   Nothing
+                                   StringBounds
+                                     { stringBoundsMinLength = Nothing
+                                     , stringBoundsMaxLength = Nothing
+                                     }))))))
                  (BimapCodec
                     _
                     _
                     (OptionalKeyWithDefaultCodec
                        "optional-with-default"
-                       (StringCodec Nothing)
+                       (StringCodec
+                          Nothing
+                          StringBounds
+                            { stringBoundsMinLength = Nothing
+                            , stringBoundsMaxLength = Nothing
+                            })
                        _
                        (Just "an optional text with a default"))))
               (BimapCodec
@@ -55,7 +89,17 @@ ObjectOfCodec
                  _
                  (OptionalKeyWithOmittedDefaultCodec
                     "optional-with-null-default"
-                    (BimapCodec _ _ (ArrayOfCodec Nothing (StringCodec Nothing)))
+                    (BimapCodec
+                       _
+                       _
+                       (ArrayOfCodec
+                          Nothing
+                          (StringCodec
+                             Nothing
+                             StringBounds
+                               { stringBoundsMinLength = Nothing
+                               , stringBoundsMaxLength = Nothing
+                               })))
                     _
                     (Just
                        "an optional list of texts with a default empty list where the empty list would be omitted"))))
@@ -69,8 +113,23 @@ ObjectOfCodec
                     _
                     (EitherCodec
                        PossiblyJointUnion
-                       (StringCodec Nothing)
-                       (BimapCodec _ _ (ArrayOfCodec Nothing (StringCodec Nothing)))))
+                       (StringCodec
+                          Nothing
+                          StringBounds
+                            { stringBoundsMinLength = Nothing
+                            , stringBoundsMaxLength = Nothing
+                            })
+                       (BimapCodec
+                          _
+                          _
+                          (ArrayOfCodec
+                             Nothing
+                             (StringCodec
+                                Nothing
+                                StringBounds
+                                  { stringBoundsMinLength = Nothing
+                                  , stringBoundsMaxLength = Nothing
+                                  })))))
                  _
                  (Just
                     "an optional list that can also be specified as a single element"))))
@@ -85,20 +144,60 @@ ObjectOfCodec
                  _
                  (EitherCodec
                     DisjointUnion
-                    (BimapCodec _ _ (EqCodec "Apple" (StringCodec Nothing)))
+                    (BimapCodec
+                       _
+                       _
+                       (EqCodec
+                          "Apple"
+                          (StringCodec
+                             Nothing
+                             StringBounds
+                               { stringBoundsMinLength = Nothing
+                               , stringBoundsMaxLength = Nothing
+                               })))
                     (BimapCodec
                        _
                        _
                        (EitherCodec
                           DisjointUnion
-                          (BimapCodec _ _ (EqCodec "Orange" (StringCodec Nothing)))
+                          (BimapCodec
+                             _
+                             _
+                             (EqCodec
+                                "Orange"
+                                (StringCodec
+                                   Nothing
+                                   StringBounds
+                                     { stringBoundsMinLength = Nothing
+                                     , stringBoundsMaxLength = Nothing
+                                     })))
                           (BimapCodec
                              _
                              _
                              (EitherCodec
                                 DisjointUnion
-                                (BimapCodec _ _ (EqCodec "Banana" (StringCodec Nothing)))
-                                (BimapCodec _ _ (EqCodec "Melon" (StringCodec Nothing))))))))))))
+                                (BimapCodec
+                                   _
+                                   _
+                                   (EqCodec
+                                      "Banana"
+                                      (StringCodec
+                                         Nothing
+                                         StringBounds
+                                           { stringBoundsMinLength = Nothing
+                                           , stringBoundsMaxLength = Nothing
+                                           })))
+                                (BimapCodec
+                                   _
+                                   _
+                                   (EqCodec
+                                      "Melon"
+                                      (StringCodec
+                                         Nothing
+                                         StringBounds
+                                           { stringBoundsMinLength = Nothing
+                                           , stringBoundsMaxLength = Nothing
+                                           }))))))))))))
      (BimapCodec
         _
         _
@@ -110,11 +209,41 @@ ObjectOfCodec
               _
               (EitherCodec
                  DisjointUnion
-                 (BimapCodec _ _ (EqCodec "circle" (StringCodec Nothing)))
+                 (BimapCodec
+                    _
+                    _
+                    (EqCodec
+                       "circle"
+                       (StringCodec
+                          Nothing
+                          StringBounds
+                            { stringBoundsMinLength = Nothing
+                            , stringBoundsMaxLength = Nothing
+                            })))
                  (BimapCodec
                     _
                     _
                     (EitherCodec
                        DisjointUnion
-                       (BimapCodec _ _ (EqCodec "square" (StringCodec Nothing)))
-                       (BimapCodec _ _ (EqCodec "rectangle" (StringCodec Nothing))))))))))
+                       (BimapCodec
+                          _
+                          _
+                          (EqCodec
+                             "square"
+                             (StringCodec
+                                Nothing
+                                StringBounds
+                                  { stringBoundsMinLength = Nothing
+                                  , stringBoundsMaxLength = Nothing
+                                  })))
+                       (BimapCodec
+                          _
+                          _
+                          (EqCodec
+                             "rectangle"
+                             (StringCodec
+                                Nothing
+                                StringBounds
+                                  { stringBoundsMinLength = Nothing
+                                  , stringBoundsMaxLength = Nothing
+                                  }))))))))))

--- a/autodocodec-api-usage/test_resources/show-codec/dlist-text.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/dlist-text.txt
@@ -1,1 +1,11 @@
-BimapCodec _ _ (ArrayOfCodec Nothing (StringCodec Nothing))
+BimapCodec
+  _
+  _
+  (ArrayOfCodec
+     Nothing
+     (StringCodec
+        Nothing
+        StringBounds
+          { stringBoundsMinLength = Nothing
+          , stringBoundsMaxLength = Nothing
+          }))

--- a/autodocodec-api-usage/test_resources/show-codec/dnonempty-text.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/dnonempty-text.txt
@@ -1,1 +1,11 @@
-BimapCodec _ _ (ArrayOfCodec Nothing (StringCodec Nothing))
+BimapCodec
+  _
+  _
+  (ArrayOfCodec
+     Nothing
+     (StringCodec
+        Nothing
+        StringBounds
+          { stringBoundsMinLength = Nothing
+          , stringBoundsMaxLength = Nothing
+          }))

--- a/autodocodec-api-usage/test_resources/show-codec/dual.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/dual.txt
@@ -1,1 +1,6 @@
-StringCodec Nothing
+StringCodec
+  Nothing
+  StringBounds
+    { stringBoundsMinLength = Nothing
+    , stringBoundsMaxLength = Nothing
+    }

--- a/autodocodec-api-usage/test_resources/show-codec/either-bool-text.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/either-bool-text.txt
@@ -3,4 +3,13 @@ EitherCodec
   (ObjectOfCodec
      Nothing (RequiredKeyCodec "Left" Nothing (BoolCodec Nothing)))
   (ObjectOfCodec
-     Nothing (RequiredKeyCodec "Right" Nothing (StringCodec Nothing)))
+     Nothing
+     (RequiredKeyCodec
+        "Right"
+        Nothing
+        (StringCodec
+           Nothing
+           StringBounds
+             { stringBoundsMinLength = Nothing
+             , stringBoundsMaxLength = Nothing
+             })))

--- a/autodocodec-api-usage/test_resources/show-codec/either-either-bool-scientific-text.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/either-either-bool-scientific-text.txt
@@ -18,4 +18,13 @@ EitherCodec
                     Nothing
                     Bounds { boundsLower = Nothing , boundsUpper = Nothing }))))))
   (ObjectOfCodec
-     Nothing (RequiredKeyCodec "Right" Nothing (StringCodec Nothing)))
+     Nothing
+     (RequiredKeyCodec
+        "Right"
+        Nothing
+        (StringCodec
+           Nothing
+           StringBounds
+             { stringBoundsMinLength = Nothing
+             , stringBoundsMaxLength = Nothing
+             })))

--- a/autodocodec-api-usage/test_resources/show-codec/example.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/example.txt
@@ -12,7 +12,15 @@ ObjectOfCodec
                              (BimapCodec
                                 _
                                 _
-                                (RequiredKeyCodec "text" (Just "a text") (StringCodec Nothing)))
+                                (RequiredKeyCodec
+                                   "text"
+                                   (Just "a text")
+                                   (StringCodec
+                                      Nothing
+                                      StringBounds
+                                        { stringBoundsMinLength = Nothing
+                                        , stringBoundsMaxLength = Nothing
+                                        })))
                              (BimapCodec
                                 _ _ (RequiredKeyCodec "bool" (Just "a bool") (BoolCodec Nothing))))
                           (BimapCodec
@@ -25,12 +33,26 @@ ObjectOfCodec
                                    _
                                    _
                                    (EitherCodec
-                                      PossiblyJointUnion NullCodec (StringCodec Nothing))))))
+                                      PossiblyJointUnion
+                                      NullCodec
+                                      (StringCodec
+                                         Nothing
+                                         StringBounds
+                                           { stringBoundsMinLength = Nothing
+                                           , stringBoundsMaxLength = Nothing
+                                           }))))))
                        (BimapCodec
                           _
                           _
                           (OptionalKeyCodec
-                             "optional" (Just "an optional text") (StringCodec Nothing))))
+                             "optional"
+                             (Just "an optional text")
+                             (StringCodec
+                                Nothing
+                                StringBounds
+                                  { stringBoundsMinLength = Nothing
+                                  , stringBoundsMaxLength = Nothing
+                                  }))))
                     (BimapCodec
                        _
                        _
@@ -41,13 +63,25 @@ ObjectOfCodec
                              _
                              _
                              (EitherCodec
-                                PossiblyJointUnion NullCodec (StringCodec Nothing))))))
+                                PossiblyJointUnion
+                                NullCodec
+                                (StringCodec
+                                   Nothing
+                                   StringBounds
+                                     { stringBoundsMinLength = Nothing
+                                     , stringBoundsMaxLength = Nothing
+                                     }))))))
                  (BimapCodec
                     _
                     _
                     (OptionalKeyWithDefaultCodec
                        "optional-with-default"
-                       (StringCodec Nothing)
+                       (StringCodec
+                          Nothing
+                          StringBounds
+                            { stringBoundsMinLength = Nothing
+                            , stringBoundsMaxLength = Nothing
+                            })
                        _
                        (Just "an optional text with a default"))))
               (BimapCodec
@@ -55,7 +89,17 @@ ObjectOfCodec
                  _
                  (OptionalKeyWithOmittedDefaultCodec
                     "optional-with-null-default"
-                    (BimapCodec _ _ (ArrayOfCodec Nothing (StringCodec Nothing)))
+                    (BimapCodec
+                       _
+                       _
+                       (ArrayOfCodec
+                          Nothing
+                          (StringCodec
+                             Nothing
+                             StringBounds
+                               { stringBoundsMinLength = Nothing
+                               , stringBoundsMaxLength = Nothing
+                               })))
                     _
                     (Just
                        "an optional list of texts with a default empty list where the empty list would be omitted"))))
@@ -69,8 +113,23 @@ ObjectOfCodec
                     _
                     (EitherCodec
                        PossiblyJointUnion
-                       (StringCodec Nothing)
-                       (BimapCodec _ _ (ArrayOfCodec Nothing (StringCodec Nothing)))))
+                       (StringCodec
+                          Nothing
+                          StringBounds
+                            { stringBoundsMinLength = Nothing
+                            , stringBoundsMaxLength = Nothing
+                            })
+                       (BimapCodec
+                          _
+                          _
+                          (ArrayOfCodec
+                             Nothing
+                             (StringCodec
+                                Nothing
+                                StringBounds
+                                  { stringBoundsMinLength = Nothing
+                                  , stringBoundsMaxLength = Nothing
+                                  })))))
                  _
                  (Just
                     "an optional list that can also be specified as a single element"))))
@@ -85,20 +144,60 @@ ObjectOfCodec
                  _
                  (EitherCodec
                     DisjointUnion
-                    (BimapCodec _ _ (EqCodec "Apple" (StringCodec Nothing)))
+                    (BimapCodec
+                       _
+                       _
+                       (EqCodec
+                          "Apple"
+                          (StringCodec
+                             Nothing
+                             StringBounds
+                               { stringBoundsMinLength = Nothing
+                               , stringBoundsMaxLength = Nothing
+                               })))
                     (BimapCodec
                        _
                        _
                        (EitherCodec
                           DisjointUnion
-                          (BimapCodec _ _ (EqCodec "Orange" (StringCodec Nothing)))
+                          (BimapCodec
+                             _
+                             _
+                             (EqCodec
+                                "Orange"
+                                (StringCodec
+                                   Nothing
+                                   StringBounds
+                                     { stringBoundsMinLength = Nothing
+                                     , stringBoundsMaxLength = Nothing
+                                     })))
                           (BimapCodec
                              _
                              _
                              (EitherCodec
                                 DisjointUnion
-                                (BimapCodec _ _ (EqCodec "Banana" (StringCodec Nothing)))
-                                (BimapCodec _ _ (EqCodec "Melon" (StringCodec Nothing))))))))))))
+                                (BimapCodec
+                                   _
+                                   _
+                                   (EqCodec
+                                      "Banana"
+                                      (StringCodec
+                                         Nothing
+                                         StringBounds
+                                           { stringBoundsMinLength = Nothing
+                                           , stringBoundsMaxLength = Nothing
+                                           })))
+                                (BimapCodec
+                                   _
+                                   _
+                                   (EqCodec
+                                      "Melon"
+                                      (StringCodec
+                                         Nothing
+                                         StringBounds
+                                           { stringBoundsMinLength = Nothing
+                                           , stringBoundsMaxLength = Nothing
+                                           }))))))))))))
      (BimapCodec
         _
         _
@@ -110,11 +209,41 @@ ObjectOfCodec
               _
               (EitherCodec
                  DisjointUnion
-                 (BimapCodec _ _ (EqCodec "circle" (StringCodec Nothing)))
+                 (BimapCodec
+                    _
+                    _
+                    (EqCodec
+                       "circle"
+                       (StringCodec
+                          Nothing
+                          StringBounds
+                            { stringBoundsMinLength = Nothing
+                            , stringBoundsMaxLength = Nothing
+                            })))
                  (BimapCodec
                     _
                     _
                     (EitherCodec
                        DisjointUnion
-                       (BimapCodec _ _ (EqCodec "square" (StringCodec Nothing)))
-                       (BimapCodec _ _ (EqCodec "rectangle" (StringCodec Nothing))))))))))
+                       (BimapCodec
+                          _
+                          _
+                          (EqCodec
+                             "square"
+                             (StringCodec
+                                Nothing
+                                StringBounds
+                                  { stringBoundsMinLength = Nothing
+                                  , stringBoundsMaxLength = Nothing
+                                  })))
+                       (BimapCodec
+                          _
+                          _
+                          (EqCodec
+                             "rectangle"
+                             (StringCodec
+                                Nothing
+                                StringBounds
+                                  { stringBoundsMinLength = Nothing
+                                  , stringBoundsMaxLength = Nothing
+                                  }))))))))))

--- a/autodocodec-api-usage/test_resources/show-codec/fruit.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/fruit.txt
@@ -3,17 +3,57 @@ BimapCodec
   _
   (EitherCodec
      DisjointUnion
-     (BimapCodec _ _ (EqCodec "Apple" (StringCodec Nothing)))
+     (BimapCodec
+        _
+        _
+        (EqCodec
+           "Apple"
+           (StringCodec
+              Nothing
+              StringBounds
+                { stringBoundsMinLength = Nothing
+                , stringBoundsMaxLength = Nothing
+                })))
      (BimapCodec
         _
         _
         (EitherCodec
            DisjointUnion
-           (BimapCodec _ _ (EqCodec "Orange" (StringCodec Nothing)))
+           (BimapCodec
+              _
+              _
+              (EqCodec
+                 "Orange"
+                 (StringCodec
+                    Nothing
+                    StringBounds
+                      { stringBoundsMinLength = Nothing
+                      , stringBoundsMaxLength = Nothing
+                      })))
            (BimapCodec
               _
               _
               (EitherCodec
                  DisjointUnion
-                 (BimapCodec _ _ (EqCodec "Banana" (StringCodec Nothing)))
-                 (BimapCodec _ _ (EqCodec "Melon" (StringCodec Nothing))))))))
+                 (BimapCodec
+                    _
+                    _
+                    (EqCodec
+                       "Banana"
+                       (StringCodec
+                          Nothing
+                          StringBounds
+                            { stringBoundsMinLength = Nothing
+                            , stringBoundsMaxLength = Nothing
+                            })))
+                 (BimapCodec
+                    _
+                    _
+                    (EqCodec
+                       "Melon"
+                       (StringCodec
+                          Nothing
+                          StringBounds
+                            { stringBoundsMinLength = Nothing
+                            , stringBoundsMaxLength = Nothing
+                            }))))))))

--- a/autodocodec-api-usage/test_resources/show-codec/identity.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/identity.txt
@@ -1,1 +1,6 @@
-StringCodec Nothing
+StringCodec
+  Nothing
+  StringBounds
+    { stringBoundsMinLength = Nothing
+    , stringBoundsMaxLength = Nothing
+    }

--- a/autodocodec-api-usage/test_resources/show-codec/lazy-text.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/lazy-text.txt
@@ -1,1 +1,9 @@
-BimapCodec _ _ (StringCodec Nothing)
+BimapCodec
+  _
+  _
+  (StringCodec
+     Nothing
+     StringBounds
+       { stringBoundsMinLength = Nothing
+       , stringBoundsMaxLength = Nothing
+       })

--- a/autodocodec-api-usage/test_resources/show-codec/legacy-object.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/legacy-object.txt
@@ -8,53 +8,146 @@ ObjectOfCodec
               _
               (EitherCodec
                  PossiblyJointUnion
-                 (RequiredKeyCodec "1" (Just "text 1") (StringCodec Nothing))
-                 (RequiredKeyCodec "1old" (Just "text 1") (StringCodec Nothing))))
+                 (RequiredKeyCodec
+                    "1"
+                    (Just "text 1")
+                    (StringCodec
+                       Nothing
+                       StringBounds
+                         { stringBoundsMinLength = Nothing
+                         , stringBoundsMaxLength = Nothing
+                         }))
+                 (RequiredKeyCodec
+                    "1old"
+                    (Just "text 1")
+                    (StringCodec
+                       Nothing
+                       StringBounds
+                         { stringBoundsMinLength = Nothing
+                         , stringBoundsMaxLength = Nothing
+                         }))))
            (BimapCodec
               _
               _
               (EitherCodec
                  PossiblyJointUnion
-                 (RequiredKeyCodec "2" (Just "text 2") (StringCodec Nothing))
-                 (RequiredKeyCodec "2old" (Just "text 2") (StringCodec Nothing)))))
+                 (RequiredKeyCodec
+                    "2"
+                    (Just "text 2")
+                    (StringCodec
+                       Nothing
+                       StringBounds
+                         { stringBoundsMinLength = Nothing
+                         , stringBoundsMaxLength = Nothing
+                         }))
+                 (RequiredKeyCodec
+                    "2old"
+                    (Just "text 2")
+                    (StringCodec
+                       Nothing
+                       StringBounds
+                         { stringBoundsMinLength = Nothing
+                         , stringBoundsMaxLength = Nothing
+                         })))))
         (BimapCodec
            _
            _
            (EitherCodec
               PossiblyJointUnion
-              (RequiredKeyCodec "3" (Just "text 3") (StringCodec Nothing))
-              (RequiredKeyCodec "3old" (Just "text 3") (StringCodec Nothing)))))
+              (RequiredKeyCodec
+                 "3"
+                 (Just "text 3")
+                 (StringCodec
+                    Nothing
+                    StringBounds
+                      { stringBoundsMinLength = Nothing
+                      , stringBoundsMaxLength = Nothing
+                      }))
+              (RequiredKeyCodec
+                 "3old"
+                 (Just "text 3")
+                 (StringCodec
+                    Nothing
+                    StringBounds
+                      { stringBoundsMinLength = Nothing
+                      , stringBoundsMaxLength = Nothing
+                      })))))
      (BimapCodec
         _
         _
         (EitherCodec
            PossiblyJointUnion
            (RequiredKeyCodec
-              "newest" (Just "newest key") (StringCodec Nothing))
+              "newest"
+              (Just "newest key")
+              (StringCodec
+                 Nothing
+                 StringBounds
+                   { stringBoundsMinLength = Nothing
+                   , stringBoundsMaxLength = Nothing
+                   }))
            (BimapCodec
               _
               _
               (EitherCodec
                  PossiblyJointUnion
-                 (RequiredKeyCodec "newer" (Just "newer key") (StringCodec Nothing))
+                 (RequiredKeyCodec
+                    "newer"
+                    (Just "newer key")
+                    (StringCodec
+                       Nothing
+                       StringBounds
+                         { stringBoundsMinLength = Nothing
+                         , stringBoundsMaxLength = Nothing
+                         }))
                  (BimapCodec
                     _
                     _
                     (EitherCodec
                        PossiblyJointUnion
-                       (RequiredKeyCodec "new" (Just "new key") (StringCodec Nothing))
+                       (RequiredKeyCodec
+                          "new"
+                          (Just "new key")
+                          (StringCodec
+                             Nothing
+                             StringBounds
+                               { stringBoundsMinLength = Nothing
+                               , stringBoundsMaxLength = Nothing
+                               }))
                        (BimapCodec
                           _
                           _
                           (EitherCodec
                              PossiblyJointUnion
-                             (RequiredKeyCodec "old" (Just "old key") (StringCodec Nothing))
+                             (RequiredKeyCodec
+                                "old"
+                                (Just "old key")
+                                (StringCodec
+                                   Nothing
+                                   StringBounds
+                                     { stringBoundsMinLength = Nothing
+                                     , stringBoundsMaxLength = Nothing
+                                     }))
                              (BimapCodec
                                 _
                                 _
                                 (EitherCodec
                                    PossiblyJointUnion
                                    (RequiredKeyCodec
-                                      "older" (Just "older key") (StringCodec Nothing))
+                                      "older"
+                                      (Just "older key")
+                                      (StringCodec
+                                         Nothing
+                                         StringBounds
+                                           { stringBoundsMinLength = Nothing
+                                           , stringBoundsMaxLength = Nothing
+                                           }))
                                    (RequiredKeyCodec
-                                      "oldest" (Just "oldest key") (StringCodec Nothing)))))))))))))
+                                      "oldest"
+                                      (Just "oldest key")
+                                      (StringCodec
+                                         Nothing
+                                         StringBounds
+                                           { stringBoundsMinLength = Nothing
+                                           , stringBoundsMaxLength = Nothing
+                                           })))))))))))))

--- a/autodocodec-api-usage/test_resources/show-codec/legacy-value.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/legacy-value.txt
@@ -8,22 +8,76 @@ ObjectOfCodec
         (ApCodec
            (ApCodec
               (BimapCodec
-                 _ _ (RequiredKeyCodec "1" (Just "text 1") (StringCodec Nothing)))
+                 _
+                 _
+                 (RequiredKeyCodec
+                    "1"
+                    (Just "text 1")
+                    (StringCodec
+                       Nothing
+                       StringBounds
+                         { stringBoundsMinLength = Nothing
+                         , stringBoundsMaxLength = Nothing
+                         })))
               (BimapCodec
-                 _ _ (RequiredKeyCodec "2" (Just "text 2") (StringCodec Nothing))))
+                 _
+                 _
+                 (RequiredKeyCodec
+                    "2"
+                    (Just "text 2")
+                    (StringCodec
+                       Nothing
+                       StringBounds
+                         { stringBoundsMinLength = Nothing
+                         , stringBoundsMaxLength = Nothing
+                         }))))
            (BimapCodec
-              _ _ (RequiredKeyCodec "3" (Just "text 3") (StringCodec Nothing))))
+              _
+              _
+              (RequiredKeyCodec
+                 "3"
+                 (Just "text 3")
+                 (StringCodec
+                    Nothing
+                    StringBounds
+                      { stringBoundsMinLength = Nothing
+                      , stringBoundsMaxLength = Nothing
+                      }))))
         (ApCodec
            (ApCodec
               (BimapCodec
                  _
                  _
-                 (RequiredKeyCodec "1old" (Just "text 1") (StringCodec Nothing)))
+                 (RequiredKeyCodec
+                    "1old"
+                    (Just "text 1")
+                    (StringCodec
+                       Nothing
+                       StringBounds
+                         { stringBoundsMinLength = Nothing
+                         , stringBoundsMaxLength = Nothing
+                         })))
               (BimapCodec
                  _
                  _
-                 (RequiredKeyCodec "2old" (Just "text 2") (StringCodec Nothing))))
+                 (RequiredKeyCodec
+                    "2old"
+                    (Just "text 2")
+                    (StringCodec
+                       Nothing
+                       StringBounds
+                         { stringBoundsMinLength = Nothing
+                         , stringBoundsMaxLength = Nothing
+                         }))))
            (BimapCodec
               _
               _
-              (RequiredKeyCodec "3old" (Just "text 3") (StringCodec Nothing))))))
+              (RequiredKeyCodec
+                 "3old"
+                 (Just "text 3")
+                 (StringCodec
+                    Nothing
+                    StringBounds
+                      { stringBoundsMinLength = Nothing
+                      , stringBoundsMaxLength = Nothing
+                      }))))))

--- a/autodocodec-api-usage/test_resources/show-codec/list-text.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/list-text.txt
@@ -1,1 +1,11 @@
-BimapCodec _ _ (ArrayOfCodec Nothing (StringCodec Nothing))
+BimapCodec
+  _
+  _
+  (ArrayOfCodec
+     Nothing
+     (StringCodec
+        Nothing
+        StringBounds
+          { stringBoundsMinLength = Nothing
+          , stringBoundsMaxLength = Nothing
+          }))

--- a/autodocodec-api-usage/test_resources/show-codec/lists-example.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/lists-example.txt
@@ -51,11 +51,31 @@ ObjectOfCodec
            (RequiredKeyCodec
               "required-non-empty"
               (Just "required non-empty list")
-              (BimapCodec _ _ (ArrayOfCodec Nothing (StringCodec Nothing))))))
+              (BimapCodec
+                 _
+                 _
+                 (ArrayOfCodec
+                    Nothing
+                    (StringCodec
+                       Nothing
+                       StringBounds
+                         { stringBoundsMinLength = Nothing
+                         , stringBoundsMaxLength = Nothing
+                         }))))))
      (BimapCodec
         _
         _
         (OptionalKeyCodec
            "optional-non-empty"
            (Just "optional non-empty list")
-           (BimapCodec _ _ (ArrayOfCodec Nothing (StringCodec Nothing))))))
+           (BimapCodec
+              _
+              _
+              (ArrayOfCodec
+                 Nothing
+                 (StringCodec
+                    Nothing
+                    StringBounds
+                      { stringBoundsMinLength = Nothing
+                      , stringBoundsMaxLength = Nothing
+                      }))))))

--- a/autodocodec-api-usage/test_resources/show-codec/local-time.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/local-time.txt
@@ -1,1 +1,11 @@
-CommentCodec "LocalTime" (BimapCodec _ _ (StringCodec Nothing))
+CommentCodec
+  "LocalTime"
+  (BimapCodec
+     _
+     _
+     (StringCodec
+        Nothing
+        StringBounds
+          { stringBoundsMinLength = Nothing
+          , stringBoundsMaxLength = Nothing
+          }))

--- a/autodocodec-api-usage/test_resources/show-codec/maybe-text.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/maybe-text.txt
@@ -1,4 +1,12 @@
 BimapCodec
   _
   _
-  (EitherCodec PossiblyJointUnion NullCodec (StringCodec Nothing))
+  (EitherCodec
+     PossiblyJointUnion
+     NullCodec
+     (StringCodec
+        Nothing
+        StringBounds
+          { stringBoundsMinLength = Nothing
+          , stringBoundsMaxLength = Nothing
+          }))

--- a/autodocodec-api-usage/test_resources/show-codec/monoid-first.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/monoid-first.txt
@@ -1,4 +1,12 @@
 BimapCodec
   _
   _
-  (EitherCodec PossiblyJointUnion NullCodec (StringCodec Nothing))
+  (EitherCodec
+     PossiblyJointUnion
+     NullCodec
+     (StringCodec
+        Nothing
+        StringBounds
+          { stringBoundsMinLength = Nothing
+          , stringBoundsMaxLength = Nothing
+          }))

--- a/autodocodec-api-usage/test_resources/show-codec/monoid-last.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/monoid-last.txt
@@ -1,4 +1,12 @@
 BimapCodec
   _
   _
-  (EitherCodec PossiblyJointUnion NullCodec (StringCodec Nothing))
+  (EitherCodec
+     PossiblyJointUnion
+     NullCodec
+     (StringCodec
+        Nothing
+        StringBounds
+          { stringBoundsMinLength = Nothing
+          , stringBoundsMaxLength = Nothing
+          }))

--- a/autodocodec-api-usage/test_resources/show-codec/nonempty-text.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/nonempty-text.txt
@@ -1,1 +1,11 @@
-BimapCodec _ _ (ArrayOfCodec Nothing (StringCodec Nothing))
+BimapCodec
+  _
+  _
+  (ArrayOfCodec
+     Nothing
+     (StringCodec
+        Nothing
+        StringBounds
+          { stringBoundsMinLength = Nothing
+          , stringBoundsMaxLength = Nothing
+          }))

--- a/autodocodec-api-usage/test_resources/show-codec/ordering.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/ordering.txt
@@ -3,11 +3,41 @@ BimapCodec
   _
   (EitherCodec
      DisjointUnion
-     (BimapCodec _ _ (EqCodec "LT" (StringCodec Nothing)))
+     (BimapCodec
+        _
+        _
+        (EqCodec
+           "LT"
+           (StringCodec
+              Nothing
+              StringBounds
+                { stringBoundsMinLength = Nothing
+                , stringBoundsMaxLength = Nothing
+                })))
      (BimapCodec
         _
         _
         (EitherCodec
            DisjointUnion
-           (BimapCodec _ _ (EqCodec "EQ" (StringCodec Nothing)))
-           (BimapCodec _ _ (EqCodec "GT" (StringCodec Nothing))))))
+           (BimapCodec
+              _
+              _
+              (EqCodec
+                 "EQ"
+                 (StringCodec
+                    Nothing
+                    StringBounds
+                      { stringBoundsMinLength = Nothing
+                      , stringBoundsMaxLength = Nothing
+                      })))
+           (BimapCodec
+              _
+              _
+              (EqCodec
+                 "GT"
+                 (StringCodec
+                    Nothing
+                    StringBounds
+                      { stringBoundsMinLength = Nothing
+                      , stringBoundsMaxLength = Nothing
+                      }))))))

--- a/autodocodec-api-usage/test_resources/show-codec/overlap.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/overlap.txt
@@ -10,9 +10,25 @@ BimapCodec
               _
               _
               (RequiredKeyCodec
-                 "type" Nothing (EqCodec "a" (StringCodec Nothing))))
+                 "type"
+                 Nothing
+                 (EqCodec
+                    "a"
+                    (StringCodec
+                       Nothing
+                       StringBounds
+                         { stringBoundsMinLength = Nothing
+                         , stringBoundsMaxLength = Nothing
+                         }))))
            (RequiredKeyCodec
-              "text" (Just "text for a") (StringCodec Nothing))))
+              "text"
+              (Just "text for a")
+              (StringCodec
+                 Nothing
+                 StringBounds
+                   { stringBoundsMinLength = Nothing
+                   , stringBoundsMaxLength = Nothing
+                   }))))
      (ObjectOfCodec
         (Just "B")
         (ApCodec
@@ -20,7 +36,16 @@ BimapCodec
               _
               _
               (RequiredKeyCodec
-                 "type" Nothing (EqCodec "b" (StringCodec Nothing))))
+                 "type"
+                 Nothing
+                 (EqCodec
+                    "b"
+                    (StringCodec
+                       Nothing
+                       StringBounds
+                         { stringBoundsMinLength = Nothing
+                         , stringBoundsMaxLength = Nothing
+                         }))))
            (RequiredKeyCodec
               "int"
               (Just "int for b")

--- a/autodocodec-api-usage/test_resources/show-codec/semigroup-first.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/semigroup-first.txt
@@ -1,1 +1,6 @@
-StringCodec Nothing
+StringCodec
+  Nothing
+  StringBounds
+    { stringBoundsMinLength = Nothing
+    , stringBoundsMaxLength = Nothing
+    }

--- a/autodocodec-api-usage/test_resources/show-codec/semigroup-last.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/semigroup-last.txt
@@ -1,1 +1,6 @@
-StringCodec Nothing
+StringCodec
+  Nothing
+  StringBounds
+    { stringBoundsMinLength = Nothing
+    , stringBoundsMaxLength = Nothing
+    }

--- a/autodocodec-api-usage/test_resources/show-codec/set-text.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/set-text.txt
@@ -1,1 +1,11 @@
-BimapCodec _ _ (ArrayOfCodec Nothing (StringCodec Nothing))
+BimapCodec
+  _
+  _
+  (ArrayOfCodec
+     Nothing
+     (StringCodec
+        Nothing
+        StringBounds
+          { stringBoundsMinLength = Nothing
+          , stringBoundsMaxLength = Nothing
+          }))

--- a/autodocodec-api-usage/test_resources/show-codec/shape.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/shape.txt
@@ -3,11 +3,41 @@ BimapCodec
   _
   (EitherCodec
      DisjointUnion
-     (BimapCodec _ _ (EqCodec "circle" (StringCodec Nothing)))
+     (BimapCodec
+        _
+        _
+        (EqCodec
+           "circle"
+           (StringCodec
+              Nothing
+              StringBounds
+                { stringBoundsMinLength = Nothing
+                , stringBoundsMaxLength = Nothing
+                })))
      (BimapCodec
         _
         _
         (EitherCodec
            DisjointUnion
-           (BimapCodec _ _ (EqCodec "square" (StringCodec Nothing)))
-           (BimapCodec _ _ (EqCodec "rectangle" (StringCodec Nothing))))))
+           (BimapCodec
+              _
+              _
+              (EqCodec
+                 "square"
+                 (StringCodec
+                    Nothing
+                    StringBounds
+                      { stringBoundsMinLength = Nothing
+                      , stringBoundsMaxLength = Nothing
+                      })))
+           (BimapCodec
+              _
+              _
+              (EqCodec
+                 "rectangle"
+                 (StringCodec
+                    Nothing
+                    StringBounds
+                      { stringBoundsMinLength = Nothing
+                      , stringBoundsMaxLength = Nothing
+                      }))))))

--- a/autodocodec-api-usage/test_resources/show-codec/string.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/string.txt
@@ -1,1 +1,9 @@
-BimapCodec _ _ (StringCodec Nothing)
+BimapCodec
+  _
+  _
+  (StringCodec
+     Nothing
+     StringBounds
+       { stringBoundsMinLength = Nothing
+       , stringBoundsMaxLength = Nothing
+       })

--- a/autodocodec-api-usage/test_resources/show-codec/text.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/text.txt
@@ -1,1 +1,6 @@
-StringCodec Nothing
+StringCodec
+  Nothing
+  StringBounds
+    { stringBoundsMinLength = Nothing
+    , stringBoundsMaxLength = Nothing
+    }

--- a/autodocodec-api-usage/test_resources/show-codec/these.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/these.txt
@@ -9,7 +9,17 @@ ObjectOfCodec
            _
            (ApCodec
               (BimapCodec
-                 _ _ (RequiredKeyCodec "text" Nothing (StringCodec Nothing)))
+                 _
+                 _
+                 (RequiredKeyCodec
+                    "text"
+                    Nothing
+                    (StringCodec
+                       Nothing
+                       StringBounds
+                         { stringBoundsMinLength = Nothing
+                         , stringBoundsMaxLength = Nothing
+                         })))
               (BimapCodec
                  _
                  _
@@ -28,7 +38,17 @@ ObjectOfCodec
        )
      , ( "this"
        , BimapCodec
-           _ _ (RequiredKeyCodec "text" Nothing (StringCodec Nothing))
+           _
+           _
+           (RequiredKeyCodec
+              "text"
+              Nothing
+              (StringCodec
+                 Nothing
+                 StringBounds
+                   { stringBoundsMinLength = Nothing
+                   , stringBoundsMaxLength = Nothing
+                   }))
        )
      , ( "that"
        , BimapCodec

--- a/autodocodec-api-usage/test_resources/show-codec/time-of-day.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/time-of-day.txt
@@ -1,1 +1,11 @@
-CommentCodec "TimeOfDay" (BimapCodec _ _ (StringCodec Nothing))
+CommentCodec
+  "TimeOfDay"
+  (BimapCodec
+     _
+     _
+     (StringCodec
+        Nothing
+        StringBounds
+          { stringBoundsMinLength = Nothing
+          , stringBoundsMaxLength = Nothing
+          }))

--- a/autodocodec-api-usage/test_resources/show-codec/utc-time.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/utc-time.txt
@@ -1,1 +1,11 @@
-CommentCodec "UTCTime" (BimapCodec _ _ (StringCodec Nothing))
+CommentCodec
+  "UTCTime"
+  (BimapCodec
+     _
+     _
+     (StringCodec
+        Nothing
+        StringBounds
+          { stringBoundsMinLength = Nothing
+          , stringBoundsMaxLength = Nothing
+          }))

--- a/autodocodec-api-usage/test_resources/show-codec/vector-text.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/vector-text.txt
@@ -1,1 +1,8 @@
-ArrayOfCodec Nothing (StringCodec Nothing)
+ArrayOfCodec
+  Nothing
+  (StringCodec
+     Nothing
+     StringBounds
+       { stringBoundsMinLength = Nothing
+       , stringBoundsMaxLength = Nothing
+       })

--- a/autodocodec-api-usage/test_resources/show-codec/via.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/via.txt
@@ -5,9 +5,23 @@ ObjectOfCodec
         _
         _
         (RequiredKeyCodec
-           "one" (Just "first field") (StringCodec Nothing)))
+           "one"
+           (Just "first field")
+           (StringCodec
+              Nothing
+              StringBounds
+                { stringBoundsMinLength = Nothing
+                , stringBoundsMaxLength = Nothing
+                })))
      (BimapCodec
         _
         _
         (RequiredKeyCodec
-           "two" (Just "second field") (StringCodec Nothing))))
+           "two"
+           (Just "second field")
+           (StringCodec
+              Nothing
+              StringBounds
+                { stringBoundsMinLength = Nothing
+                , stringBoundsMaxLength = Nothing
+                }))))

--- a/autodocodec-api-usage/test_resources/show-codec/war.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/war.txt
@@ -8,4 +8,9 @@ BimapCodec
         _
         (IntegerCodec
            Nothing Bounds { boundsLower = Just 0 , boundsUpper = Just 255 }))
-     (StringCodec Nothing))
+     (StringCodec
+        Nothing
+        StringBounds
+          { stringBoundsMinLength = Nothing
+          , stringBoundsMaxLength = Nothing
+          }))

--- a/autodocodec-api-usage/test_resources/show-codec/zoned-time.txt
+++ b/autodocodec-api-usage/test_resources/show-codec/zoned-time.txt
@@ -1,1 +1,11 @@
-CommentCodec "ZonedTime" (BimapCodec _ _ (StringCodec Nothing))
+CommentCodec
+  "ZonedTime"
+  (BimapCodec
+     _
+     _
+     (StringCodec
+        Nothing
+        StringBounds
+          { stringBoundsMinLength = Nothing
+          , stringBoundsMaxLength = Nothing
+          }))

--- a/autodocodec-exact/CHANGELOG.md
+++ b/autodocodec-exact/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.0.2] - 2026-07-14
+
+### Changed
+
+* Lower bound on `autodocodec >=0.6`
+
 ## [0.0.0.1] - 2025-06-20
 
 ### Changed

--- a/autodocodec-exact/autodocodec-exact.cabal
+++ b/autodocodec-exact/autodocodec-exact.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           autodocodec-exact
-version:        0.0.0.1
+version:        0.0.0.2
 synopsis:       Exact decoder for autodocodec
 homepage:       https://github.com/NorfairKing/autodocodec#readme
 bug-reports:    https://github.com/NorfairKing/autodocodec/issues
@@ -33,7 +33,7 @@ library
   build-depends:
       aeson
     , aeson-pretty
-    , autodocodec >=0.5.0.0
+    , autodocodec >=0.6.0.0
     , base >=4.7 && <5
     , bytestring
     , containers

--- a/autodocodec-exact/default.nix
+++ b/autodocodec-exact/default.nix
@@ -4,7 +4,7 @@
 }:
 mkDerivation {
   pname = "autodocodec-exact";
-  version = "0.0.0.1";
+  version = "0.0.0.2";
   src = ./.;
   libraryHaskellDepends = [
     aeson aeson-pretty autodocodec base bytestring containers mtl

--- a/autodocodec-exact/package.yaml
+++ b/autodocodec-exact/package.yaml
@@ -1,5 +1,5 @@
 name: autodocodec-exact
-version: 0.0.0.1
+version: 0.0.0.2
 github: "NorfairKing/autodocodec"
 license: MIT
 author: "Tom Sydney Kerckhove"
@@ -19,7 +19,7 @@ library:
   dependencies:
   - aeson
   - aeson-pretty
-  - autodocodec >= 0.5.0.0
+  - autodocodec >= 0.6.0.0
   - bytestring
   - containers
   - mtl

--- a/autodocodec-exact/src/Autodocodec/Exact.hs
+++ b/autodocodec-exact/src/Autodocodec/Exact.hs
@@ -107,10 +107,12 @@ goV value = \case
       case value of
         JSON.Bool b -> return $ coerce b
         _ -> exactError $ ExactParseErrorTypeMismatch "a boolean" value
-  StringCodec mname ->
+  StringCodec mname bounds ->
     withNamed mname $
       case value of
-        JSON.String s -> return $ coerce s
+        JSON.String s -> case checkStringBounds bounds s of
+          Left err -> exactError $ ExactParseErrorStringOutOfBounds bounds s err
+          Right s' -> pure $ coerce s'
         _ -> exactError $ ExactParseErrorTypeMismatch "a string" value
   IntegerCodec mname bounds ->
     withNamed mname $
@@ -490,6 +492,7 @@ data ExactParseErrorMessage
   | ExactParseErrorDisjointBothSucceeded
   | ExactParseErrorDisjointBothFailed !ExactParseError !ExactParseError
   | ExactParseErrorUnsafeNumber !(Bounds Scientific) !Scientific !String
+  | ExactParseErrorStringOutOfBounds !StringBounds !Text !String
   | ExactParseErrorNumberOutOfBounds !(Bounds Scientific) !Scientific !String
   | ExactParseErrorIntegerOutOfBounds !(Bounds Integer) !Integer !String
   | ExactParseErrorMissingRequiredKey !Key !JSON.Object
@@ -551,6 +554,8 @@ prettyExactParseErrorMessage = \case
     [unwords ["Number is out of bounds:", show @Scientific s], err]
   ExactParseErrorIntegerOutOfBounds _ i err ->
     [unwords ["Integer is out of bounds:", show @Integer i], err]
+  ExactParseErrorStringOutOfBounds _ t err ->
+    [unwords ["String is out of bounds:", show @Text t], err]
   ExactParseErrorMissingRequiredKey key o ->
     appendOnLine' ["Missing required key:", show @Key key ++ ", in object:"] (showObject o)
   ExactParseErrorMissingDiscriminator key o ->

--- a/autodocodec-nix/CHANGELOG.md
+++ b/autodocodec-nix/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.0.2] - 2026-07-14
+
+### Changed
+
+* Lower bound on `autodocodec >=0.6`
+
 ## [0.1.0.1] - 2026-04-25
 
 ### Changed

--- a/autodocodec-nix/autodocodec-nix.cabal
+++ b/autodocodec-nix/autodocodec-nix.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           autodocodec-nix
-version:        0.1.0.1
+version:        0.1.0.2
 synopsis:       Autodocodec interpreters for nix
 homepage:       https://github.com/NorfairKing/autodocodec#readme
 bug-reports:    https://github.com/NorfairKing/autodocodec/issues
@@ -35,7 +35,7 @@ library
       src
   build-depends:
       aeson
-    , autodocodec >=0.4.0.0
+    , autodocodec >=0.6.0.0
     , base >=4.7 && <5
     , containers
     , scientific

--- a/autodocodec-nix/default.nix
+++ b/autodocodec-nix/default.nix
@@ -3,7 +3,7 @@
 }:
 mkDerivation {
   pname = "autodocodec-nix";
-  version = "0.1.0.1";
+  version = "0.1.0.2";
   src = ./.;
   libraryHaskellDepends = [
     aeson autodocodec base containers scientific text

--- a/autodocodec-nix/package.yaml
+++ b/autodocodec-nix/package.yaml
@@ -1,5 +1,5 @@
 name: autodocodec-nix
-version: 0.1.0.1
+version: 0.1.0.2
 github: "NorfairKing/autodocodec"
 license: MIT
 author: "Tom Sydney Kerckhove"
@@ -18,7 +18,7 @@ library:
   source-dirs: src
   dependencies:
   - aeson
-  - autodocodec >= 0.4.0.0
+  - autodocodec >= 0.6.0.0
   - containers
   - scientific
   - text

--- a/autodocodec-nix/src/Autodocodec/Nix/Options.hs
+++ b/autodocodec-nix/src/Autodocodec/Nix/Options.hs
@@ -71,7 +71,7 @@ valueCodecNixOptionType = fmap simplifyOptionType . go
     go = \case
       NullCodec -> Just OptionTypeNull
       BoolCodec _ -> Just $ OptionTypeSimple "lib.types.bool"
-      StringCodec _ -> Just $ OptionTypeSimple "lib.types.str"
+      StringCodec _ _ -> Just $ OptionTypeSimple "lib.types.str"
       IntegerCodec _ bounds -> Just $
         OptionTypeSimple $
           case guessIntegerBoundsSymbolic bounds of

--- a/autodocodec-openapi3/CHANGELOG.md
+++ b/autodocodec-openapi3/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.3.0.2] - 2026-07-14
+
+### Changed
+
+* Lower bound on `autodocodec >=0.6`
+
 ## [0.3.0.1] - 2025-07-09
 
 * Fix discriminated union OpenAPI schema generation (see #61 for more info)

--- a/autodocodec-openapi3/autodocodec-openapi3.cabal
+++ b/autodocodec-openapi3/autodocodec-openapi3.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           autodocodec-openapi3
-version:        0.3.0.1
+version:        0.3.0.2
 synopsis:       Autodocodec interpreters for openapi3
 homepage:       https://github.com/NorfairKing/autodocodec#readme
 bug-reports:    https://github.com/NorfairKing/autodocodec/issues
@@ -34,7 +34,7 @@ library
       src
   build-depends:
       aeson
-    , autodocodec >=0.4.0.0
+    , autodocodec >=0.6.0.0
     , base >=4.7 && <5
     , insert-ordered-containers
     , lens

--- a/autodocodec-openapi3/default.nix
+++ b/autodocodec-openapi3/default.nix
@@ -3,7 +3,7 @@
 }:
 mkDerivation {
   pname = "autodocodec-openapi3";
-  version = "0.3.0.1";
+  version = "0.3.0.2";
   src = ./.;
   libraryHaskellDepends = [
     aeson autodocodec base insert-ordered-containers lens mtl openapi3

--- a/autodocodec-openapi3/package.yaml
+++ b/autodocodec-openapi3/package.yaml
@@ -1,5 +1,5 @@
 name: autodocodec-openapi3
-version: 0.3.0.1
+version: 0.3.0.2
 github: "NorfairKing/autodocodec"
 license: MIT
 author: "Tom Sydney Kerckhove"
@@ -18,7 +18,7 @@ library:
   source-dirs: src
   dependencies:
   - aeson
-  - autodocodec >= 0.4.0.0
+  - autodocodec >= 0.6.0.0
   - unordered-containers
   - insert-ordered-containers
   - lens

--- a/autodocodec-openapi3/src/Autodocodec/OpenAPI/Schema.hs
+++ b/autodocodec-openapi3/src/Autodocodec/OpenAPI/Schema.hs
@@ -43,12 +43,14 @@ declareNamedSchemaVia c' Proxy = evalStateT (go c') mempty
               { _schemaType = Just OpenApiNull
               }
       BoolCodec mname -> lift $ NamedSchema mname <$> declareSchema (Proxy :: Proxy Bool)
-      StringCodec mname StringBounds{..} -> do
+      StringCodec mname StringBounds {..} -> do
         s <- lift $ declareSchema (Proxy :: Proxy Text)
-        pure $ NamedSchema mname $ s
-          { _schemaMinLength = fromIntegral <$> stringBoundsMinLength
-          , _schemaMaxLength = fromIntegral <$> stringBoundsMaxLength
-          }
+        pure $
+          NamedSchema mname $
+            s
+              { _schemaMinLength = fromIntegral <$> stringBoundsMinLength,
+                _schemaMaxLength = fromIntegral <$> stringBoundsMaxLength
+              }
       IntegerCodec mname mBounds -> do
         s <- lift $ declareSchema (Proxy :: Proxy Integer)
         let addNumberBounds Bounds {..} s_ =

--- a/autodocodec-openapi3/src/Autodocodec/OpenAPI/Schema.hs
+++ b/autodocodec-openapi3/src/Autodocodec/OpenAPI/Schema.hs
@@ -43,7 +43,12 @@ declareNamedSchemaVia c' Proxy = evalStateT (go c') mempty
               { _schemaType = Just OpenApiNull
               }
       BoolCodec mname -> lift $ NamedSchema mname <$> declareSchema (Proxy :: Proxy Bool)
-      StringCodec mname -> lift $ NamedSchema mname <$> declareSchema (Proxy :: Proxy Text)
+      StringCodec mname StringBounds{..} -> do
+        s <- lift $ declareSchema (Proxy :: Proxy Text)
+        pure $ NamedSchema mname $ s
+          { _schemaMinLength = fromIntegral <$> stringBoundsMinLength
+          , _schemaMaxLength = fromIntegral <$> stringBoundsMaxLength
+          }
       IntegerCodec mname mBounds -> do
         s <- lift $ declareSchema (Proxy :: Proxy Integer)
         let addNumberBounds Bounds {..} s_ =

--- a/autodocodec-schema/CHANGELOG.md
+++ b/autodocodec-schema/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.0.2] - 2026-07-14
+
+### Changed
+
+* Lower bound on `autodocodec >=0.6`
+
 ## [0.2.0.1] - 2025-02-13
 
 ### Added

--- a/autodocodec-schema/autodocodec-schema.cabal
+++ b/autodocodec-schema/autodocodec-schema.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           autodocodec-schema
-version:        0.2.0.1
+version:        0.2.0.2
 synopsis:       Autodocodec interpreters for JSON Schema
 homepage:       https://github.com/NorfairKing/autodocodec#readme
 bug-reports:    https://github.com/NorfairKing/autodocodec/issues
@@ -32,7 +32,7 @@ library
       src
   build-depends:
       aeson
-    , autodocodec >=0.4.0.0
+    , autodocodec >=0.6.0.0
     , base >=4.7 && <5
     , containers
     , mtl

--- a/autodocodec-schema/default.nix
+++ b/autodocodec-schema/default.nix
@@ -4,7 +4,7 @@
 }:
 mkDerivation {
   pname = "autodocodec-schema";
-  version = "0.2.0.1";
+  version = "0.2.0.2";
   src = ./.;
   libraryHaskellDepends = [
     aeson autodocodec base containers mtl scientific text

--- a/autodocodec-schema/package.yaml
+++ b/autodocodec-schema/package.yaml
@@ -1,5 +1,5 @@
 name: autodocodec-schema
-version: 0.2.0.1
+version: 0.2.0.2
 github: "NorfairKing/autodocodec"
 license: MIT
 author: "Tom Sydney Kerckhove"
@@ -18,7 +18,7 @@ library:
   source-dirs: src
   dependencies:
   - aeson
-  - autodocodec >=0.4.0.0
+  - autodocodec >=0.6.0.0
   - containers
   - mtl
   - scientific

--- a/autodocodec-schema/src/Autodocodec/Schema.hs
+++ b/autodocodec-schema/src/Autodocodec/Schema.hs
@@ -56,7 +56,7 @@ data JSONSchema
   = AnySchema
   | NullSchema
   | BoolSchema
-  | StringSchema
+  | StringSchema !StringBounds
   | IntegerSchema !(Bounds Integer)
   | NumberSchema !(Bounds Scientific)
   | ArraySchema !JSONSchema
@@ -92,7 +92,12 @@ instance ToJSON JSONSchema where
         AnySchema -> []
         NullSchema -> ["type" JSON..= ("null" :: Text)]
         BoolSchema -> ["type" JSON..= ("boolean" :: Text)]
-        StringSchema -> ["type" JSON..= ("string" :: Text)]
+        StringSchema StringBounds {..} -> 
+          catMaybes
+            [ Just ("type" JSON..= ("string" :: Text)),
+              ("maxLength" JSON..=) <$> stringBoundsMaxLength,
+              ("minLength" JSON..=) <$> stringBoundsMinLength
+            ]
         IntegerSchema Bounds {..} ->
           catMaybes
             [ Just ("type" JSON..= ("integer" :: Text)),
@@ -144,7 +149,10 @@ instance FromJSON JSONSchema where
     fmap (commentFunc . defsFunc) $ case mt :: Maybe Text of
       Just "null" -> pure NullSchema
       Just "boolean" -> pure BoolSchema
-      Just "string" -> pure StringSchema
+      Just "string" -> do
+        stringBoundsMinLength <- o JSON..:? "minLength"
+        stringBoundsMaxLength <- o JSON..:? "maxLength"
+        pure $ StringSchema StringBounds {..}
       Just "integer" -> do
         boundsLower <- o JSON..:? "minimum"
         boundsUpper <- o JSON..:? "maximum"
@@ -295,7 +303,7 @@ goValue :: ValueCodec input output -> State (Set Text) JSONSchema
 goValue = \case
   NullCodec -> pure NullSchema
   BoolCodec mname -> pure $ maybe id CommentSchema mname BoolSchema
-  StringCodec mname -> pure $ maybe id CommentSchema mname StringSchema
+  StringCodec mname mBounds -> pure $ maybe id CommentSchema mname $ StringSchema mBounds
   IntegerCodec mname mBounds -> pure $ maybe id CommentSchema mname $ IntegerSchema mBounds
   NumberCodec mname mBounds -> pure $ maybe id CommentSchema mname $ NumberSchema mBounds
   ArrayOfCodec mname c -> do
@@ -419,8 +427,10 @@ validateValue value = \case
   BoolSchema -> pure $ case value of
     JSON.Bool _ -> True
     _ -> False
-  StringSchema -> pure $ case value of
-    JSON.String _ -> True
+  StringSchema bounds -> pure $ case value of
+    JSON.String s -> case checkStringBounds bounds s of
+      Left _ -> False
+      Right _ -> True
     _ -> False
   IntegerSchema bounds -> pure $ case value of
     JSON.Number s -> case checkBounds (fromInteger <$> bounds) s of

--- a/autodocodec-schema/src/Autodocodec/Schema.hs
+++ b/autodocodec-schema/src/Autodocodec/Schema.hs
@@ -92,7 +92,7 @@ instance ToJSON JSONSchema where
         AnySchema -> []
         NullSchema -> ["type" JSON..= ("null" :: Text)]
         BoolSchema -> ["type" JSON..= ("boolean" :: Text)]
-        StringSchema StringBounds {..} -> 
+        StringSchema StringBounds {..} ->
           catMaybes
             [ Just ("type" JSON..= ("string" :: Text)),
               ("maxLength" JSON..=) <$> stringBoundsMaxLength,

--- a/autodocodec-servant-multipart/CHANGELOG.md
+++ b/autodocodec-servant-multipart/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.0.0.3] - 2026-07-14
+
+### Changed
+
+* Lower bound on `autodocodec >=0.6`
+
 ## [0.0.0.2] - 2025-06-20
 
 ### Changed

--- a/autodocodec-servant-multipart/autodocodec-servant-multipart.cabal
+++ b/autodocodec-servant-multipart/autodocodec-servant-multipart.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           autodocodec-servant-multipart
-version:        0.0.0.2
+version:        0.0.0.3
 synopsis:       Autodocodec interpreters for Servant Multipart
 homepage:       https://github.com/NorfairKing/autodocodec#readme
 bug-reports:    https://github.com/NorfairKing/autodocodec/issues
@@ -32,7 +32,7 @@ library
       src
   build-depends:
       aeson
-    , autodocodec >=0.5.0.0
+    , autodocodec >=0.6.0.0
     , base >=4.7 && <5
     , bytestring
     , servant-multipart

--- a/autodocodec-servant-multipart/default.nix
+++ b/autodocodec-servant-multipart/default.nix
@@ -4,7 +4,7 @@
 }:
 mkDerivation {
   pname = "autodocodec-servant-multipart";
-  version = "0.0.0.2";
+  version = "0.0.0.3";
   src = ./.;
   libraryHaskellDepends = [
     aeson autodocodec base bytestring servant-multipart

--- a/autodocodec-servant-multipart/package.yaml
+++ b/autodocodec-servant-multipart/package.yaml
@@ -1,5 +1,5 @@
 name: autodocodec-servant-multipart
-version: 0.0.0.2
+version: 0.0.0.3
 github: "NorfairKing/autodocodec"
 license: MIT
 author: "Tom Sydney Kerckhove"
@@ -18,7 +18,7 @@ library:
   source-dirs: src
   dependencies:
   - aeson
-  - autodocodec >=0.5.0.0
+  - autodocodec >=0.6.0.0
   - bytestring
   - servant-multipart
   - servant-multipart-api

--- a/autodocodec-servant-multipart/src/Autodocodec/Multipart.hs
+++ b/autodocodec-servant-multipart/src/Autodocodec/Multipart.hs
@@ -97,7 +97,7 @@ toMultipartVia = flip go
         case coerce a of
           True -> "True"
           False -> "False"
-      StringCodec _ -> coerce a
+      StringCodec _ _ -> coerce a
       vc ->
         let value = toJSONVia vc a
          in case value of
@@ -237,7 +237,7 @@ fromMultipartVia = flip go
         "true" -> Right True
         "True" -> Right True
         _ -> Left $ "Unknown bool: " <> show t
-      StringCodec _ -> Right (coerce t)
+      StringCodec _ _ -> Right (coerce t)
       vc -> case JSON.parseEither (parseJSONVia vc) (JSON.String t) of
         Right a -> Right a
         Left _ -> do

--- a/autodocodec-swagger2/CHANGELOG.md
+++ b/autodocodec-swagger2/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.1.0.1] - 2026-07-14
+
+### Changed
+
+* Lower bound on `autodocodec >=0.6`
+
 ## [0.1.0.0] - 2024-07-29
 
 * Dropped support for orphan instances.

--- a/autodocodec-swagger2/autodocodec-swagger2.cabal
+++ b/autodocodec-swagger2/autodocodec-swagger2.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           autodocodec-swagger2
-version:        0.1.0.0
+version:        0.1.0.1
 synopsis:       Autodocodec interpreters for swagger2
 homepage:       https://github.com/NorfairKing/autodocodec#readme
 bug-reports:    https://github.com/NorfairKing/autodocodec/issues
@@ -34,7 +34,7 @@ library
       src
   build-depends:
       aeson
-    , autodocodec >=0.4.0.0
+    , autodocodec >=0.6.0.0
     , base >=4.7 && <5
     , insert-ordered-containers
     , scientific

--- a/autodocodec-swagger2/default.nix
+++ b/autodocodec-swagger2/default.nix
@@ -3,7 +3,7 @@
 }:
 mkDerivation {
   pname = "autodocodec-swagger2";
-  version = "0.1.0.0";
+  version = "0.1.0.1";
   src = ./.;
   libraryHaskellDepends = [
     aeson autodocodec base insert-ordered-containers scientific

--- a/autodocodec-swagger2/package.yaml
+++ b/autodocodec-swagger2/package.yaml
@@ -1,5 +1,5 @@
 name: autodocodec-swagger2
-version: 0.1.0.0
+version: 0.1.0.1
 github: "NorfairKing/autodocodec"
 license: MIT
 author: "Tom Sydney Kerckhove"
@@ -18,7 +18,7 @@ library:
   source-dirs: src
   dependencies:
   - aeson
-  - autodocodec >=0.4.0.0
+  - autodocodec >=0.6.0.0
   - insert-ordered-containers
   - scientific
   - swagger2

--- a/autodocodec-swagger2/src/Autodocodec/Swagger/Schema.hs
+++ b/autodocodec-swagger2/src/Autodocodec/Swagger/Schema.hs
@@ -40,7 +40,17 @@ declareNamedSchemaVia c' Proxy = go c'
                     }
               }
       BoolCodec mname -> NamedSchema mname <$> declareSchema (Proxy :: Proxy Bool)
-      StringCodec mname -> NamedSchema mname <$> declareSchema (Proxy :: Proxy Text)
+      StringCodec mname mBounds -> do
+        s <- declareSchema (Proxy :: Proxy Text)
+        let addStringBounds StringBounds {..} s_ =
+              s_
+                { _schemaParamSchema =
+                    (_schemaParamSchema s_)
+                      { _paramSchemaMinLength = fromIntegral <$> stringBoundsMinLength,
+                        _paramSchemaMaxLength = fromIntegral <$> stringBoundsMaxLength
+                      }
+                }
+        pure $ NamedSchema mname $ addStringBounds mBounds s
       IntegerCodec mname mBounds -> do
         s <- declareSchema (Proxy :: Proxy Integer)
         let addNumberBounds Bounds {..} s_ =

--- a/autodocodec-yaml/CHANGELOG.md
+++ b/autodocodec-yaml/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.4.0.3] - 2026-07-14
+
+### Changed
+
+* Lower bound on `autodocodec >=0.6`
+
 ## [0.4.0.2] - 2025-06-20
 
 ### Changed

--- a/autodocodec-yaml/autodocodec-yaml.cabal
+++ b/autodocodec-yaml/autodocodec-yaml.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           autodocodec-yaml
-version:        0.4.0.2
+version:        0.4.0.3
 synopsis:       Autodocodec interpreters for yaml
 homepage:       https://github.com/NorfairKing/autodocodec#readme
 bug-reports:    https://github.com/NorfairKing/autodocodec/issues
@@ -34,8 +34,8 @@ library
   hs-source-dirs:
       src
   build-depends:
-      autodocodec >=0.5.0.0
-    , autodocodec-schema >=0.2.0.1
+      autodocodec >=0.6.0.0
+    , autodocodec-schema >=0.2.0.2
     , base >=4.7 && <5
     , bytestring
     , containers

--- a/autodocodec-yaml/default.nix
+++ b/autodocodec-yaml/default.nix
@@ -4,7 +4,7 @@
 }:
 mkDerivation {
   pname = "autodocodec-yaml";
-  version = "0.4.0.2";
+  version = "0.4.0.3";
   src = ./.;
   libraryHaskellDepends = [
     autodocodec autodocodec-schema base bytestring containers path

--- a/autodocodec-yaml/package.yaml
+++ b/autodocodec-yaml/package.yaml
@@ -1,5 +1,5 @@
 name: autodocodec-yaml
-version: 0.4.0.2
+version: 0.4.0.3
 github: "NorfairKing/autodocodec"
 license: MIT
 author: "Tom Sydney Kerckhove"
@@ -17,8 +17,8 @@ dependencies:
 library:
   source-dirs: src
   dependencies:
-  - autodocodec >= 0.5.0.0
-  - autodocodec-schema >=0.2.0.1
+  - autodocodec >= 0.6.0.0
+  - autodocodec-schema >=0.2.0.2
   - bytestring
   - containers
   - path

--- a/autodocodec-yaml/src/Autodocodec/Yaml/Encode.hs
+++ b/autodocodec-yaml/src/Autodocodec/Yaml/Encode.hs
@@ -34,7 +34,7 @@ toYamlVia = flip go
     go a = \case
       NullCodec -> Yaml.null
       BoolCodec _ -> Yaml.bool (coerce a :: Bool)
-      StringCodec _ -> Yaml.string (coerce a :: Text)
+      StringCodec _ _ -> Yaml.string (coerce a :: Text)
       IntegerCodec _ _ -> Yaml.scientific $ fromInteger (coerce a :: Integer)
       NumberCodec _ _ -> yamlNumber (coerce a :: Scientific)
       ArrayOfCodec _ c -> Yaml.array (map (`go` c) (V.toList (coerce a :: Vector _)))

--- a/autodocodec-yaml/src/Autodocodec/Yaml/Schema.hs
+++ b/autodocodec-yaml/src/Autodocodec/Yaml/Schema.hs
@@ -137,7 +137,7 @@ goValue = \case
   AnySchema -> [[fore yellow "<any>"]]
   NullSchema -> [[fore yellow "null"]]
   BoolSchema -> [[fore yellow "<boolean>"]]
-  StringSchema -> [[fore yellow "<string>"]]
+  StringSchema _ -> [[fore yellow "<string>"]] -- TODO bounds?
   IntegerSchema bounds -> integerBoundsChunks bounds
   NumberSchema _ -> [[fore yellow "<number>"]] -- TODO bounds?
   ArraySchema s ->

--- a/autodocodec/CHANGELOG.md
+++ b/autodocodec/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## [0.6.0.0] - 2026-07-22
+
+This is technically a breaking change but it's unlikely that you'll need to
+change any of your codecs.
+
+### Changed
+
+* Changed `StringCodec` to include `StringBounds` to represent the minimal/maximal length of a string.
+
+## Added
+
+* `textWithBoundsCodec`
+* `stringWithBoundsCodec`
+
 ## [0.5.0.0] - 2025-06-20
 
 This is technically a breaking change but it's unlikely that you'll need to

--- a/autodocodec/autodocodec.cabal
+++ b/autodocodec/autodocodec.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           autodocodec
-version:        0.5.0.0
+version:        0.6.0.0
 synopsis:       Self-documenting encoder and decoder
 homepage:       https://github.com/NorfairKing/autodocodec#readme
 bug-reports:    https://github.com/NorfairKing/autodocodec/issues

--- a/autodocodec/default.nix
+++ b/autodocodec/default.nix
@@ -4,7 +4,7 @@
 }:
 mkDerivation {
   pname = "autodocodec";
-  version = "0.5.0.0";
+  version = "0.6.0.0";
   src = ./.;
   libraryHaskellDepends = [
     aeson base bytestring containers dlist hashable mtl scientific text

--- a/autodocodec/package.yaml
+++ b/autodocodec/package.yaml
@@ -1,5 +1,5 @@
 name: autodocodec
-version: 0.5.0.0
+version: 0.6.0.0
 github: "NorfairKing/autodocodec"
 license: MIT
 author: "Tom Sydney Kerckhove"

--- a/autodocodec/src/Autodocodec/Aeson/Decode.hs
+++ b/autodocodec/src/Autodocodec/Aeson/Decode.hs
@@ -65,8 +65,9 @@ parseJSONContextVia codec_ context_ =
       BoolCodec mname -> case mname of
         Nothing -> coerce (parseJSON value :: JSON.Parser Bool)
         Just name -> coerce $ withBool (T.unpack name) pure value
-      StringCodec mname bounds -> coerce $
-          ( \f -> case mname of        
+      StringCodec mname bounds ->
+        coerce $
+          ( \f -> case mname of
               Nothing -> parseJSON value >>= f
               Just name -> withText (T.unpack name) f value
           )

--- a/autodocodec/src/Autodocodec/Aeson/Decode.hs
+++ b/autodocodec/src/Autodocodec/Aeson/Decode.hs
@@ -66,9 +66,15 @@ parseJSONContextVia codec_ context_ =
       BoolCodec mname -> case mname of
         Nothing -> coerce (parseJSON value :: JSON.Parser Bool)
         Just name -> coerce $ withBool (T.unpack name) pure value
-      StringCodec mname -> case mname of
-        Nothing -> coerce (parseJSON value :: JSON.Parser Text)
-        Just name -> coerce $ withText (T.unpack name) pure value
+      StringCodec mname bounds -> coerce $
+          ( \f -> case mname of        
+              Nothing -> parseJSON value >>= f
+              Just name -> withText (T.unpack name) f value
+          )
+            ( \s -> case checkStringBounds bounds s of
+                Left err -> fail err
+                Right s' -> pure s'
+            )
       IntegerCodec mname bounds ->
         coerce $
           ( \f -> do

--- a/autodocodec/src/Autodocodec/Aeson/Decode.hs
+++ b/autodocodec/src/Autodocodec/Aeson/Decode.hs
@@ -29,7 +29,6 @@ import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
 import Data.Map (Map)
 import Data.Scientific as Scientific
-import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Vector (Vector)
 import qualified Data.Vector as V

--- a/autodocodec/src/Autodocodec/Aeson/Encode.hs
+++ b/autodocodec/src/Autodocodec/Aeson/Encode.hs
@@ -74,7 +74,7 @@ toJSONVia = flip go
     go a = \case
       NullCodec -> JSON.Null
       BoolCodec _ -> toJSON (coerce a :: Bool)
-      StringCodec _ -> toJSON (coerce a :: Text)
+      StringCodec _ _ -> toJSON (coerce a :: Text)
       IntegerCodec _ _ -> toJSON (coerce a :: Integer)
       NumberCodec _ _ -> toJSON (coerce a :: Scientific)
       ArrayOfCodec _ c -> toJSON (fmap (`go` c) (coerce a :: Vector _))
@@ -130,7 +130,7 @@ toEncodingVia = flip go
     go a = \case
       NullCodec -> JSON.null_
       BoolCodec _ -> JSON.bool (coerce a :: Bool)
-      StringCodec _ -> JSON.text (coerce a :: Text)
+      StringCodec _ _ -> JSON.text (coerce a :: Text)
       IntegerCodec _ _ -> JSON.scientific (fromInteger (coerce a :: Integer) :: Scientific)
       NumberCodec _ _ -> JSON.scientific (coerce a :: Scientific)
       ArrayOfCodec _ c -> JSON.list (`go` c) (V.toList (coerce a :: Vector _))

--- a/autodocodec/src/Autodocodec/Codec.hs
+++ b/autodocodec/src/Autodocodec/Codec.hs
@@ -1357,6 +1357,20 @@ boolCodec = BoolCodec Nothing
 textCodec :: JSONCodec Text
 textCodec = StringCodec Nothing emptyStringBounds
 
+-- | Codec for 'Text' values with bounds
+--
+--
+-- === Example usage
+--
+-- >>> JSON.parseMaybe (parseJSONVia (textWithBoundsCodec StringBounds { stringBoundsMinLength = Just 1, stringBoundsMaxLength = Just 10})) (String "hello")
+-- Just "hello"
+--
+-- >>> JSON.parseMaybe (parseJSONVia (textWithBoundsCodec StringBounds { stringBoundsMinLength = Just 1, stringBoundsMaxLength = Just 4})) (String "hello")
+-- Nothing
+
+textWithBoundsCodec :: StringBounds -> JSONCodec Text
+textWithBoundsCodec bounds = StringCodec Nothing bounds
+
 -- | Codec for 'String' values
 --
 --
@@ -1379,6 +1393,32 @@ textCodec = StringCodec Nothing emptyStringBounds
 -- This is a 'String' version of 'textCodec'.
 stringCodec :: JSONCodec String
 stringCodec = dimapCodec T.unpack T.pack textCodec
+
+-- | Codec for 'String' values with bounds
+--
+--
+-- === Example usage
+--
+-- >>> JSON.parseMaybe (parseJSONVia (stringWithBoundsCodec StringBounds { stringBoundsMinLength = Just 1, stringBoundsMaxLength = Just 10})) (String "hello")
+-- Just "hello"
+--
+-- >>> JSON.parseMaybe (parseJSONVia (stringWithBoundsCodec StringBounds { stringBoundsMinLength = Just 1, stringBoundsMaxLength = Just 4})) (String "hello")
+-- Nothing
+--
+--
+-- === WARNING
+--
+-- This codec uses 'T.unpack' and 'T.pack' to dimap a 'textWithBoundsCodec', so it __does not roundtrip__.
+--
+-- >>> toJSONVia (stringWithBoundsCodec StringBounds { stringBoundsMinLength = Just 1, stringBoundsMaxLength = Just 10}) "\55296"
+-- String "\65533"
+--
+--
+-- ==== API Note
+--
+-- This is a 'String' version of 'textWithBoundsCodec'.
+stringWithBoundsCodec :: StringBounds -> JSONCodec String
+stringWithBoundsCodec bounds = dimapCodec T.unpack T.pack (textWithBoundsCodec bounds)
 
 -- | Codec for 'Scientific' values
 --

--- a/autodocodec/src/Autodocodec/Codec.hs
+++ b/autodocodec/src/Autodocodec/Codec.hs
@@ -98,6 +98,8 @@ data Codec context input output where
     (Coercible a Text, Coercible b Text) =>
     -- | Name of the @string@, for error messages and documentation.
     Maybe Text ->
+    -- | Bounds for the string, these are checked and documented
+    StringBounds ->
     ValueCodec a b
   -- | Encode 'Integer' to a @number@ value, and decode a @number@ value as an 'Integer'.
   --
@@ -296,6 +298,31 @@ data Codec context input output where
     ObjectCodec input output ->
     ObjectCodec input newOutput
 
+data StringBounds = StringBounds
+  { stringBoundsMinLength :: !(Maybe Natural)
+  , stringBoundsMaxLength :: !(Maybe Natural)
+  --, stringBoundsPattern   :: !(Maybe Text)  -- not sure if a dependency to a regex library is justified
+  }
+  deriving (Show, Eq, Ord, Generic)
+
+instance Validity StringBounds where
+  validate StringBounds {..} =
+    mconcat
+      [ validate stringBoundsMinLength,
+        validate stringBoundsMaxLength
+      ]
+
+emptyStringBounds :: StringBounds
+emptyStringBounds = StringBounds Nothing Nothing
+
+checkStringBounds :: StringBounds -> Text -> Either String Text
+checkStringBounds StringBounds {..} s =
+  case stringBoundsMinLength of
+    Just lo | T.length s < fromIntegral lo -> Left $ unwords ["String", show s, "is shorter than the lower bound", show lo]
+    _ -> case stringBoundsMaxLength of
+      Just hi | T.length s > fromIntegral hi -> Left $ unwords ["String", show s, "is longer than the upper bound", show hi]
+      _ -> Right s
+
 data Bounds a = Bounds
   { -- | Lower bound, inclusive
     boundsLower :: !(Maybe a),
@@ -410,7 +437,7 @@ showCodecABit = ($ "") . (`evalState` S.empty) . go 0
     go d = \case
       NullCodec -> pure $ showString "NullCodec"
       BoolCodec mName -> pure $ showParen (d > 10) $ showString "BoolCodec " . showsPrec 11 mName
-      StringCodec mName -> pure $ showParen (d > 10) $ showString "StringCodec " . showsPrec 11 mName
+      StringCodec mName mbs -> pure $ showParen (d > 10) $ showString "StringCodec " . showsPrec 11 mName . showString " " . showsPrec 11 mbs
       IntegerCodec mName mbs -> pure $ showParen (d > 10) $ showString "IntegerCodec " . showsPrec 11 mName . showString " " . showsPrec 11 mbs
       NumberCodec mName mbs -> pure $ showParen (d > 10) $ showString "NumberCodec " . showsPrec 11 mName . showString " " . showsPrec 11 mbs
       ArrayOfCodec mName c -> (\s -> showParen (d > 10) $ showString "ArrayOfCodec " . showsPrec 11 mName . showString " " . s) <$> go 11 c
@@ -1328,7 +1355,7 @@ boolCodec = BoolCodec Nothing
 --
 -- > textCodec = StringCodec Nothing
 textCodec :: JSONCodec Text
-textCodec = StringCodec Nothing
+textCodec = StringCodec Nothing emptyStringBounds
 
 -- | Codec for 'String' values
 --

--- a/autodocodec/src/Autodocodec/Codec.hs
+++ b/autodocodec/src/Autodocodec/Codec.hs
@@ -299,7 +299,9 @@ data Codec context input output where
     ObjectCodec input newOutput
 
 data StringBounds = StringBounds
-  { stringBoundsMinLength :: !(Maybe Natural),
+  { -- | Lower bound, inclusive. A string is valid if its length is greater than, or equal to, this value.
+    stringBoundsMinLength :: !(Maybe Natural),
+    -- | Upper bound, inclusive. A string is valid if its length is less than, or equal to, this value.
     stringBoundsMaxLength :: !(Maybe Natural)
   }
   deriving (Show, Eq, Ord, Generic)

--- a/autodocodec/src/Autodocodec/Codec.hs
+++ b/autodocodec/src/Autodocodec/Codec.hs
@@ -1358,6 +1358,9 @@ textCodec = StringCodec Nothing emptyStringBounds
 
 -- | Codec for 'Text' values with bounds
 --
+-- During parsing, only 'Text' values within the given boundaries are accepted.
+--
+-- During rendering, the value is not checked and is simply output as is.
 --
 -- === Example usage
 --
@@ -1394,6 +1397,9 @@ stringCodec = dimapCodec T.unpack T.pack textCodec
 
 -- | Codec for 'String' values with bounds
 --
+-- During parsing, only 'String' values within the given boundaries are accepted.
+--
+-- During rendering, the value is not checked and is simply output as is.
 --
 -- === Example usage
 --

--- a/autodocodec/src/Autodocodec/Codec.hs
+++ b/autodocodec/src/Autodocodec/Codec.hs
@@ -299,9 +299,8 @@ data Codec context input output where
     ObjectCodec input newOutput
 
 data StringBounds = StringBounds
-  { stringBoundsMinLength :: !(Maybe Natural)
-  , stringBoundsMaxLength :: !(Maybe Natural)
-  --, stringBoundsPattern   :: !(Maybe Text)  -- not sure if a dependency to a regex library is justified
+  { stringBoundsMinLength :: !(Maybe Natural),
+    stringBoundsMaxLength :: !(Maybe Natural)
   }
   deriving (Show, Eq, Ord, Generic)
 
@@ -1367,7 +1366,6 @@ textCodec = StringCodec Nothing emptyStringBounds
 --
 -- >>> JSON.parseMaybe (parseJSONVia (textWithBoundsCodec StringBounds { stringBoundsMinLength = Just 1, stringBoundsMaxLength = Just 4})) (String "hello")
 -- Nothing
-
 textWithBoundsCodec :: StringBounds -> JSONCodec Text
 textWithBoundsCodec bounds = StringCodec Nothing bounds
 


### PR DESCRIPTION
Not sure if this change is a good idea, but I was looking for a way to support minLength/maxLength for JSON specs.
https://datatracker.ietf.org/doc/html/draft-bhutton-json-schema-validation-01#name-validation-keywords-for-str

So I tried to follow the standard already established by integer bounds and implemented the similar thing for strings.