### PR TITLE
Added a new escape hatch to enable backends to extend in whatever way they like (for now only realized for OpenApi3).

### DIFF
--- a/autodocodec-exact/src/Autodocodec/Exact.hs
+++ b/autodocodec-exact/src/Autodocodec/Exact.hs
@@ -240,6 +240,8 @@ goV value = \case
   CommentCodec comment c ->
     withContext (ExactParseContextPieceComment comment) $
       goV value c
+  ExtensionCodec _ c ->
+    goV value c
   ReferenceCodec ref c ->
     withContext (ExactParseContextPieceReference ref) $
       goV value c

--- a/autodocodec-nix/src/Autodocodec/Nix/Options.hs
+++ b/autodocodec-nix/src/Autodocodec/Nix/Options.hs
@@ -98,6 +98,7 @@ valueCodecNixOptionType = fmap simplifyOptionType . go
       BimapCodec _ _ c -> go c
       EitherCodec _ c1 c2 -> Just $ OptionTypeOneOf (map mTyp [go c1, go c2])
       CommentCodec _ c -> go c
+      ExtensionCodec _ c -> go c
       ReferenceCodec {} -> Nothing -- TODO: let-binding?
 
 -- [tag:NixOptionNullable]

--- a/autodocodec-openapi3/autodocodec-openapi3.cabal
+++ b/autodocodec-openapi3/autodocodec-openapi3.cabal
@@ -36,6 +36,7 @@ library
       aeson
     , autodocodec >=0.4.0.0
     , base >=4.7 && <5
+    , containers
     , insert-ordered-containers
     , lens
     , mtl

--- a/autodocodec-openapi3/default.nix
+++ b/autodocodec-openapi3/default.nix
@@ -1,13 +1,14 @@
-{ mkDerivation, aeson, autodocodec, base, insert-ordered-containers
-, lens, lib, mtl, openapi3, scientific, text, unordered-containers
+{ mkDerivation, aeson, autodocodec, base, containers
+, insert-ordered-containers, lens, lib, mtl, openapi3, scientific
+, text, unordered-containers
 }:
 mkDerivation {
   pname = "autodocodec-openapi3";
   version = "0.3.0.1";
   src = ./.;
   libraryHaskellDepends = [
-    aeson autodocodec base insert-ordered-containers lens mtl openapi3
-    scientific text unordered-containers
+    aeson autodocodec base containers insert-ordered-containers lens
+    mtl openapi3 scientific text unordered-containers
   ];
   homepage = "https://github.com/NorfairKing/autodocodec#readme";
   description = "Autodocodec interpreters for openapi3";

--- a/autodocodec-openapi3/package.yaml
+++ b/autodocodec-openapi3/package.yaml
@@ -19,6 +19,7 @@ library:
   dependencies:
   - aeson
   - autodocodec >= 0.4.0.0
+  - containers
   - unordered-containers
   - insert-ordered-containers
   - lens

--- a/autodocodec-openapi3/src/Autodocodec/OpenAPI/Schema.hs
+++ b/autodocodec-openapi3/src/Autodocodec/OpenAPI/Schema.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Autodocodec.OpenAPI.Schema where
 
@@ -16,15 +17,21 @@ import Control.Monad.State.Lazy (StateT, evalStateT, runStateT)
 import qualified Control.Monad.State.Lazy as State
 import Control.Monad.Trans (lift)
 import qualified Data.Aeson as Aeson
+import Data.Data (typeRep)
+import Data.Dynamic (fromDynamic)
 import qualified Data.Foldable as Foldable
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
 import qualified Data.HashMap.Strict.InsOrd as InsOrdHashMap
+import qualified Data.Map as Map
 import Data.OpenApi as OpenAPI
 import Data.OpenApi.Declare as OpenAPI
 import Data.Proxy
 import Data.Scientific
 import Data.Text (Text)
+
+-- | Extension type for OpenAPI schema extensions.
+data OpenAPIExt = OpenAPIExt (Schema -> Schema)
 
 -- | Use a type's 'codec' to implement 'declareNamedSchema'.
 declareNamedSchemaViaCodec :: (HasCodec value) => Proxy value -> Declare (Definitions Schema) NamedSchema
@@ -127,6 +134,13 @@ declareNamedSchemaVia c' Proxy = evalStateT (go c') mempty
       CommentCodec t c -> do
         NamedSchema mName s <- go c
         pure $ NamedSchema mName $ addDoc t s
+      ExtensionCodec ext c ->
+        let f = case Map.lookup (typeRep (Proxy @OpenAPIExt)) ext >>= fromDynamic of
+              Just (OpenAPIExt f') -> f'
+              Nothing -> id
+         in do
+              NamedSchema mName s <- go c
+              pure $ NamedSchema mName (f s)
       ReferenceCodec n c -> do
         seenSchemas <- State.get
         case HashMap.lookup n seenSchemas of

--- a/autodocodec-openapi3/src/Autodocodec/OpenAPI/Schema.hs
+++ b/autodocodec-openapi3/src/Autodocodec/OpenAPI/Schema.hs
@@ -18,7 +18,7 @@ import qualified Control.Monad.State.Lazy as State
 import Control.Monad.Trans (lift)
 import qualified Data.Aeson as Aeson
 import Data.Data (typeRep)
-import Data.Dynamic (fromDynamic)
+import Data.Dynamic (fromDynamic, toDyn)
 import qualified Data.Foldable as Foldable
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
@@ -284,3 +284,27 @@ declareSpecificSchemaRef mName s =
       known <- looks (InsOrdHashMap.member n)
       when (not known) $ declare $ InsOrdHashMap.singleton n s
       pure $ Ref (Reference n)
+
+-- | Attach an OpenAPI-specific schema extension to a codec.
+--
+-- The given function is applied to the 'NamedSchema' produced for this codec,
+-- and may declare additional schema definitions.
+addOpenAPIExt ::
+  (NamedSchema -> Declare (Definitions Schema) NamedSchema) ->
+  ValueCodec input output ->
+  ValueCodec input output
+addOpenAPIExt f =
+  ExtensionCodec
+    (Map.singleton (typeRep (Proxy @OpenAPIExt)) (toDyn (OpenAPIExt f)))
+
+-- | Like 'addOpenAPIExt' but only transforms the inner 'Schema'.
+modifyOpenAPISchema ::
+  (Schema -> Schema) ->
+  ValueCodec input output ->
+  ValueCodec input output
+modifyOpenAPISchema f =
+  addOpenAPIExt (\(NamedSchema mName s) -> pure (NamedSchema mName (f s)))
+
+-- | Like 'modifyOpenAPISchema' but just replaces the inner 'Schema' with the schema defined by the proxy type.
+useOpenAPISchema :: (ToSchema a) => Proxy a -> ValueCodec input output -> ValueCodec input output
+useOpenAPISchema p = modifyOpenAPISchema (\_ -> toSchema p)

--- a/autodocodec-openapi3/src/Autodocodec/OpenAPI/Schema.hs
+++ b/autodocodec-openapi3/src/Autodocodec/OpenAPI/Schema.hs
@@ -31,7 +31,7 @@ import Data.Scientific
 import Data.Text (Text)
 
 -- | Extension type for OpenAPI schema extensions.
-data OpenAPIExt = OpenAPIExt (Schema -> Schema)
+data OpenAPIExt = OpenAPIExt (NamedSchema -> Declare (Definitions Schema) NamedSchema)
 
 -- | Use a type's 'codec' to implement 'declareNamedSchema'.
 declareNamedSchemaViaCodec :: (HasCodec value) => Proxy value -> Declare (Definitions Schema) NamedSchema
@@ -137,10 +137,10 @@ declareNamedSchemaVia c' Proxy = evalStateT (go c') mempty
       ExtensionCodec ext c ->
         let f = case Map.lookup (typeRep (Proxy @OpenAPIExt)) ext >>= fromDynamic of
               Just (OpenAPIExt f') -> f'
-              Nothing -> id
+              Nothing -> pure
          in do
-              NamedSchema mName s <- go c
-              pure $ NamedSchema mName (f s)
+              ns <- go c
+              lift $ f ns
       ReferenceCodec n c -> do
         seenSchemas <- State.get
         case HashMap.lookup n seenSchemas of

--- a/autodocodec-schema/src/Autodocodec/Schema.hs
+++ b/autodocodec-schema/src/Autodocodec/Schema.hs
@@ -315,6 +315,7 @@ goValue = \case
       DisjointUnion -> OneOfSchema (goOneOf (s1 :| [s2]))
       PossiblyJointUnion -> AnyOfSchema (goAnyOf (s1 :| [s2]))
   BimapCodec _ _ c -> goValue c
+  ExtensionCodec _ c -> goValue c
   CommentCodec t c -> CommentSchema t <$> goValue c
   ReferenceCodec name c -> do
     alreadySeen <- gets (S.member name)

--- a/autodocodec-swagger2/src/Autodocodec/Swagger/Schema.hs
+++ b/autodocodec-swagger2/src/Autodocodec/Swagger/Schema.hs
@@ -116,6 +116,7 @@ declareNamedSchemaVia c' Proxy = go c'
               { _schemaParamSchema = mempty {_paramSchemaEnum = Just [toJSONVia valCodec val]}
               }
       BimapCodec _ _ c -> go c
+      ExtensionCodec _ c -> go c
       EitherCodec u c1 c2 -> do
         ns1 <- go c1
         let s1 = _namedSchemaSchema ns1

--- a/autodocodec-yaml/src/Autodocodec/Yaml/Encode.hs
+++ b/autodocodec-yaml/src/Autodocodec/Yaml/Encode.hs
@@ -48,6 +48,7 @@ toYamlVia = flip go
         Left a1 -> go a1 c1
         Right a2 -> go a2 c2
       CommentCodec _ c -> go a c
+      ExtensionCodec _ c -> go a c
       ReferenceCodec _ c -> go a c
 
     goObject :: a -> ObjectCodec a void -> [(Text, YamlBuilder)]

--- a/autodocodec/src/Autodocodec/Aeson/Decode.hs
+++ b/autodocodec/src/Autodocodec/Aeson/Decode.hs
@@ -161,6 +161,7 @@ parseJSONContextVia codec_ context_ =
           Just (_, c) ->
             go value c
       CommentCodec _ c -> go value c
+      ExtensionCodec _ c -> go value c
       ReferenceCodec _ c -> go value c
       RequiredKeyCodec k c _ -> do
         valueAtKey <- (value :: JSON.Object) JSON..: Compat.toKey k

--- a/autodocodec/src/Autodocodec/Aeson/Encode.hs
+++ b/autodocodec/src/Autodocodec/Aeson/Encode.hs
@@ -88,6 +88,7 @@ toJSONVia = flip go
         Left a1 -> go a1 c1
         Right a2 -> go a2 c2
       CommentCodec _ c -> go a c
+      ExtensionCodec _ c -> go a c
       ReferenceCodec _ c -> go a c
 
 -- | Implement 'JSON.toEncoding' via a type's codec.
@@ -140,6 +141,7 @@ toEncodingVia = flip go
       ValueCodec -> JSON.value (coerce a :: JSON.Value)
       EqCodec value c -> go value c
       BimapCodec _ g c -> go (g a) c
+      ExtensionCodec _ c -> go a c
       EitherCodec _ c1 c2 -> case (coerce a :: Either _ _) of
         Left a1 -> go a1 c1
         Right a2 -> go a2 c2

--- a/autodocodec/src/Autodocodec/Codec.hs
+++ b/autodocodec/src/Autodocodec/Codec.hs
@@ -26,6 +26,8 @@ import Data.Aeson (FromJSON, FromJSONKey, ToJSON, ToJSONKey)
 import qualified Data.Aeson as JSON
 import qualified Data.Aeson.Types as JSON
 import Data.Coerce (Coercible)
+import Data.Data (TypeRep)
+import Data.Dynamic (Dynamic)
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashMap.Strict as HashMap
 import Data.Hashable
@@ -227,6 +229,14 @@ data Codec context input output where
     Text ->
     ValueCodec input output ->
     ValueCodec input output
+  -- | An extension codec
+  --
+  -- This is used to add implementation-irrelevant but human-relevant information.
+  ExtensionCodec ::
+    -- | Extension
+    Map TypeRep Dynamic ->
+    ValueCodec input output ->
+    ValueCodec input output
   -- | A reference codec
   --
   -- This is used for naming a codec, so that recursive codecs can have a finite schema.
@@ -426,6 +436,7 @@ showCodecABit = ($ "") . (`evalState` S.empty) . go 0
         let csList = showString "[" . foldr (.) id (intersperse (showString ", ") cs) . showString "]"
         pure $ showParen (d > 10) $ showString "DiscriminatedUnionCodec " . showsPrec 11 propertyName . showString " _ " . csList
       CommentCodec comment c -> (\s -> showParen (d > 10) $ showString "CommentCodec " . showsPrec 11 comment . showString " " . s) <$> go 11 c
+      ExtensionCodec _ c -> (\s -> showParen (d > 10) $ showString "ExtensionCodec _ " . s) <$> go 11 c
       ReferenceCodec name c -> do
         alreadySeen <- gets (S.member name)
         if alreadySeen


### PR DESCRIPTION
This might be a more controversial change, but it gives some more freedom to design custom data types.

Let's stick with the example involving string lengths. If we want to express the boundaries at the type level we would create a type like.

```haskell
type BoundedText :: Nat -> Nat -> Type
newtype BoundedText (lo :: Nat) (hi :: Nat) = BoundedText { unBoundedText :: String }
  deriving stock (Show, Eq)
```
(for the sake of clarity, I'm leaving out the safety check via the necessary smart constructor)

With its corresponding schema:

```haskell
instance (KnownNat lo, KnownNat hi) => ToSchema (BoundedText lo hi) where
  declareNamedSchema _ = do
    NamedSchema _ s <- declareNamedSchema (Proxy @Text)
    let lo = fromIntegral (natVal (Proxy @lo))
        hi = fromIntegral (natVal (Proxy @hi))
    pure $ NamedSchema Nothing (s { _schemaMinLength = Just lo, _schemaMaxLength = Just hi })
```

With the extension point we would now be able to re-use this instance e.g. with:

```haskell
instance(KnownNat lo, KnownNat hi) => HasCodec (BoundedText lo hi) where
  codec = bimapCodec validate unBoundedText (useOpenAPISchema (Proxy @(BoundedText lo hi)) codec)
    where
      lo = fromIntegral (natVal (Proxy @lo)) :: Int
      hi = fromIntegral (natVal (Proxy @hi)) :: Int
      validate t
        | let n = length t, n >= lo, n <= hi = Right (BoundedText t)
        | otherwise = Left ("length not in [" <> show lo <> "," <> show hi <> "]")
```

For sure we could achieve the same result if we write HasCodec instances by hand for the data types that include our custom type. But this is inconvenient for deep nesting and also clutters the code - so I like to write it as simple as possible, like:

```haskell
type Address :: Type
data Address = Address { street :: String, city :: BoundedText 5 10, zipCode :: String }
  deriving stock (Generic, Show, Eq, Ord)
  deriving (FromJSON, ToJSON) via (Autodocodec Address)
  deriving (ToSchema) via (AutodocodecOpenApi Address)
```

For sure this is overkill for this simple example. But I hope this illustrates the motivation behind this change. I think it even gets more important for more complex modelled domain types.