### PR TITLE
Add autodocodec-http-api-data for form-urlencoded data

### DIFF
--- a/autodocodec-api-usage/autodocodec-api-usage.cabal
+++ b/autodocodec-api-usage/autodocodec-api-usage.cabal
@@ -517,6 +517,7 @@ library
       QuickCheck
     , aeson
     , autodocodec >=0.6.0.0
+    , autodocodec-http-api-data
     , autodocodec-openapi3
     , autodocodec-schema
     , autodocodec-servant-multipart
@@ -529,6 +530,7 @@ library
     , genvalidity-aeson
     , genvalidity-scientific
     , genvalidity-text
+    , http-api-data
     , openapi3
     , scientific
     , servant-multipart
@@ -546,6 +548,7 @@ test-suite autodocodec-api-usage-test
       Autodocodec.Aeson.SchemaSpec
       Autodocodec.AesonSpec
       Autodocodec.ExactSpec
+      Autodocodec.FormUrlEncodedSpec
       Autodocodec.MultipartSpec
       Autodocodec.Nix.OptionsSpec
       Autodocodec.Nix.RenderSpec
@@ -566,6 +569,7 @@ test-suite autodocodec-api-usage-test
     , autodocodec
     , autodocodec-api-usage
     , autodocodec-exact
+    , autodocodec-http-api-data
     , autodocodec-nix
     , autodocodec-openapi3
     , autodocodec-schema
@@ -585,6 +589,7 @@ test-suite autodocodec-api-usage-test
     , genvalidity-sydtest-aeson
     , genvalidity-text
     , genvalidity-time
+    , http-api-data
     , openapi3
     , pretty-show
     , safe-coloured-text
@@ -595,6 +600,7 @@ test-suite autodocodec-api-usage-test
     , sydtest-aeson
     , text
     , time
+    , unordered-containers
     , vector
     , yaml
   default-language: Haskell2010

--- a/autodocodec-api-usage/default.nix
+++ b/autodocodec-api-usage/default.nix
@@ -1,38 +1,39 @@
 { mkDerivation, aeson, autodocodec, autodocodec-exact
-, autodocodec-nix, autodocodec-openapi3, autodocodec-schema
-, autodocodec-servant-multipart, autodocodec-swagger2
-, autodocodec-yaml, base, bytestring, containers, criterion
-, deepseq, dlist, genvalidity, genvalidity-aeson
-, genvalidity-containers, genvalidity-criterion, genvalidity-dlist
-, genvalidity-scientific, genvalidity-sydtest
+, autodocodec-http-api-data, autodocodec-nix, autodocodec-openapi3
+, autodocodec-schema, autodocodec-servant-multipart
+, autodocodec-swagger2, autodocodec-yaml, base, bytestring
+, containers, criterion, deepseq, dlist, genvalidity
+, genvalidity-aeson, genvalidity-containers, genvalidity-criterion
+, genvalidity-dlist, genvalidity-scientific, genvalidity-sydtest
 , genvalidity-sydtest-aeson, genvalidity-text, genvalidity-time
-, lib, openapi3, pretty-show, QuickCheck, safe-coloured-text
-, scientific, servant-multipart, servant-multipart-api, swagger2
-, sydtest, sydtest-aeson, sydtest-discover, text, time
-, unordered-containers, vector, yaml
+, http-api-data, lib, openapi3, pretty-show, QuickCheck
+, safe-coloured-text, scientific, servant-multipart
+, servant-multipart-api, swagger2, sydtest, sydtest-aeson
+, sydtest-discover, text, time, unordered-containers, vector, yaml
 }:
 mkDerivation {
   pname = "autodocodec-api-usage";
   version = "0.0.0.1";
   src = ./.;
   libraryHaskellDepends = [
-    aeson autodocodec autodocodec-openapi3 autodocodec-schema
-    autodocodec-servant-multipart autodocodec-swagger2 autodocodec-yaml
-    base bytestring deepseq genvalidity genvalidity-aeson
-    genvalidity-scientific genvalidity-text openapi3 QuickCheck
-    scientific servant-multipart servant-multipart-api swagger2 text
+    aeson autodocodec autodocodec-http-api-data autodocodec-openapi3
+    autodocodec-schema autodocodec-servant-multipart
+    autodocodec-swagger2 autodocodec-yaml base bytestring deepseq
+    genvalidity genvalidity-aeson genvalidity-scientific
+    genvalidity-text http-api-data openapi3 QuickCheck scientific
+    servant-multipart servant-multipart-api swagger2 text
     unordered-containers yaml
   ];
   testHaskellDepends = [
-    aeson autodocodec autodocodec-exact autodocodec-nix
-    autodocodec-openapi3 autodocodec-schema
+    aeson autodocodec autodocodec-exact autodocodec-http-api-data
+    autodocodec-nix autodocodec-openapi3 autodocodec-schema
     autodocodec-servant-multipart autodocodec-swagger2 autodocodec-yaml
     base bytestring containers dlist genvalidity genvalidity-aeson
     genvalidity-containers genvalidity-dlist genvalidity-scientific
     genvalidity-sydtest genvalidity-sydtest-aeson genvalidity-text
-    genvalidity-time openapi3 pretty-show QuickCheck safe-coloured-text
-    scientific servant-multipart-api swagger2 sydtest sydtest-aeson
-    text time vector yaml
+    genvalidity-time http-api-data openapi3 pretty-show QuickCheck
+    safe-coloured-text scientific servant-multipart-api swagger2
+    sydtest sydtest-aeson text time unordered-containers vector yaml
   ];
   testToolDepends = [ sydtest-discover ];
   benchmarkHaskellDepends = [

--- a/autodocodec-api-usage/package.yaml
+++ b/autodocodec-api-usage/package.yaml
@@ -20,6 +20,7 @@ library:
   - QuickCheck
   - aeson
   - autodocodec >=0.6.0.0
+  - autodocodec-http-api-data
   - autodocodec-openapi3
   - autodocodec-schema
   - autodocodec-servant-multipart
@@ -31,6 +32,7 @@ library:
   - genvalidity-aeson
   - genvalidity-scientific
   - genvalidity-text
+  - http-api-data
   - openapi3
   - scientific
   - servant-multipart
@@ -57,6 +59,7 @@ tests:
     - autodocodec
     - autodocodec-api-usage
     - autodocodec-exact
+    - autodocodec-http-api-data
     - autodocodec-openapi3
     - autodocodec-schema
     - autodocodec-servant-multipart
@@ -75,6 +78,7 @@ tests:
     - genvalidity-sydtest-aeson
     - genvalidity-text
     - genvalidity-time
+    - http-api-data
     - openapi3
     - pretty-show
     - safe-coloured-text
@@ -84,6 +88,7 @@ tests:
     - sydtest
     - sydtest-aeson
     - text
+    - unordered-containers
     - time
     - yaml
     - vector

--- a/autodocodec-api-usage/src/Autodocodec/Usage.hs
+++ b/autodocodec-api-usage/src/Autodocodec/Usage.hs
@@ -17,6 +17,7 @@ module Autodocodec.Usage where
 
 import Autodocodec
 import Autodocodec.Aeson ()
+import Autodocodec.FormUrlEncoded ()
 import Autodocodec.Multipart
 import Autodocodec.OpenAPI ()
 import Autodocodec.OpenAPI.DerivingVia (AutodocodecOpenApi)
@@ -45,6 +46,7 @@ import GHC.Generics (Generic)
 import Servant.Multipart
 import Servant.Multipart.API as Servant
 import Test.QuickCheck
+import Web.FormUrlEncoded
 
 -- | A type that's encoded as @null@.
 data NullUnit = NullUnit
@@ -294,6 +296,72 @@ instance ToMultipart tag Example where
       )
       []
 
+instance FromForm Example where
+  fromForm form =
+    Example
+      <$> lookupUnique "text" form
+      <*> ( lookupUnique "bool" form >>= \case
+              "true" -> Right True
+              "false" -> Right False
+              _ -> Left "Unknown bool"
+          )
+      <*> ( lookupUnique "maybe" form >>= \case
+              "null" -> Right Nothing
+              t -> Right (Just t)
+          )
+      <*> lookupMaybe "optional" form
+      <*> ( lookupMaybe "optional-or-null" form >>= \case
+              Nothing -> Right Nothing
+              Just "null" -> Right Nothing
+              Just t -> Right (Just t)
+          )
+      <*> (fromMaybe "foobar" <$> lookupMaybe "optional-with-default" form)
+      <*> pure (lookupAll "optional-with-null-default" form)
+      <*> pure (lookupAll "single-or-list" form)
+      <*> ( lookupUnique "fruit" form >>= \case
+              "Apple" -> Right Apple
+              "Orange" -> Right Orange
+              "Banana" -> Right Banana
+              "Melon" -> Right Melon
+              _ -> Left "unknown fruit"
+          )
+      <*> ( lookupUnique "shape" form >>= \case
+              "circle" -> Right ShapeCircle
+              "square" -> Right ShapeSquare
+              "rectangle" -> Right ShapeRectangle
+              _ -> Left "unknown shape"
+          )
+
+-- Built without the helpers in Autodocodec.FormUrlEncoded, so that comparing
+-- this against the interpreter compares two independent spellings.
+instance ToForm Example where
+  toForm Example {..} =
+    Form $
+      HashMap.fromList $
+        concat
+          [ [ ("text", [exampleText]),
+              ("bool", [if exampleBool then "true" else "false"]),
+              ("maybe", [fromMaybe "null" exampleRequiredMaybe]),
+              ("optional-with-default", [exampleOptionalWithDefault]),
+              ("fruit", [T.pack $ show exampleFruit]),
+              ( "shape",
+                [ case exampleShape of
+                    ShapeCircle -> "circle"
+                    ShapeSquare -> "square"
+                    ShapeRectangle -> "rectangle"
+                ]
+              )
+            ],
+            [("optional", [o]) | o <- maybeToList exampleOptional],
+            [("optional-or-null", [o]) | o <- maybeToList exampleOptionalOrNull],
+            [ ("optional-with-null-default", exampleOptionalWithNullDefault)
+            | not (null exampleOptionalWithNullDefault)
+            ],
+            [ ("single-or-list", exampleSingleOrList)
+            | not (null exampleSingleOrList)
+            ]
+          ]
+
 newtype Derived = Derived {unDerived :: Example}
   deriving stock (Show, Eq, Generic)
   deriving newtype (Validity, GenValid, FromJSON, ToJSON)
@@ -308,7 +376,9 @@ data ListsExample = ListsExample
   deriving (Show, Eq, Generic)
   deriving
     ( Servant.FromMultipart tag,
-      Servant.ToMultipart tag
+      Servant.ToMultipart tag,
+      FromForm,
+      ToForm
     )
     via Autodocodec ListsExample
   deriving (OpenAPI.ToSchema) via (AutodocodecOpenApi ListsExample)
@@ -463,7 +533,9 @@ data Via = Via
     ( FromJSON,
       ToJSON,
       Servant.FromMultipart tag,
-      Servant.ToMultipart tag
+      Servant.ToMultipart tag,
+      FromForm,
+      ToForm
     )
     via (Autodocodec Via)
   deriving (OpenAPI.ToSchema) via AutodocodecOpenApi Via
@@ -525,7 +597,9 @@ data LegacyValue = LegacyValue
     ( FromJSON,
       ToJSON,
       Servant.FromMultipart tag,
-      Servant.ToMultipart tag
+      Servant.ToMultipart tag,
+      FromForm,
+      ToForm
     )
     via (Autodocodec LegacyValue)
   deriving (OpenAPI.ToSchema) via AutodocodecOpenApi LegacyValue
@@ -567,7 +641,9 @@ data LegacyObject = LegacyObject
     ( FromJSON,
       ToJSON,
       Servant.FromMultipart tag,
-      Servant.ToMultipart tag
+      Servant.ToMultipart tag,
+      FromForm,
+      ToForm
     )
     via (Autodocodec LegacyObject)
   deriving (OpenAPI.ToSchema) via AutodocodecOpenApi LegacyObject
@@ -707,7 +783,9 @@ data These
     ( FromJSON,
       ToJSON,
       Servant.FromMultipart tag,
-      Servant.ToMultipart tag
+      Servant.ToMultipart tag,
+      FromForm,
+      ToForm
     )
     via (Autodocodec These)
   deriving (OpenAPI.ToSchema) via AutodocodecOpenApi These
@@ -750,7 +828,9 @@ data Expression
     ( FromJSON,
       ToJSON,
       Servant.FromMultipart tag,
-      Servant.ToMultipart tag
+      Servant.ToMultipart tag,
+      FromForm,
+      ToForm
     )
     via (Autodocodec Expression)
   deriving (OpenAPI.ToSchema) via AutodocodecOpenApi Expression
@@ -824,7 +904,9 @@ data Overlap
   deriving (FromJSON, ToJSON) via Autodocodec Overlap
   deriving
     ( Servant.FromMultipart tag,
-      Servant.ToMultipart tag
+      Servant.ToMultipart tag,
+      FromForm,
+      ToForm
     )
     via Autodocodec Overlap
   deriving (OpenAPI.ToSchema) via (AutodocodecOpenApi Overlap)

--- a/autodocodec-api-usage/test/Autodocodec/FormUrlEncodedSpec.hs
+++ b/autodocodec-api-usage/test/Autodocodec/FormUrlEncodedSpec.hs
@@ -1,0 +1,214 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Autodocodec.FormUrlEncodedSpec (spec) where
+
+import Autodocodec
+import Autodocodec.FormUrlEncoded
+import Autodocodec.Usage
+import Data.Bifunctor (first)
+import Data.Data
+import qualified Data.HashMap.Strict as HashMap
+import Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.Text as T
+import Test.Syd
+import Test.Syd.Validity
+import Test.Syd.Validity.Utils
+import Web.FormUrlEncoded
+
+spec :: Spec
+spec = do
+  -- Two fields under one key, which is the only shape that tells a
+  -- values-concatenating union apart from a left-biased one.
+  describe "a key that two fields share" $ do
+    let sharedKeyCodec :: ObjectCodec (T.Text, T.Text) (T.Text, T.Text)
+        sharedKeyCodec =
+          (,)
+            <$> requiredField' "k" .= fst
+            <*> requiredField' "k" .= snd
+    it "encodes the values of both fields" $
+      toFormVia sharedKeyCodec ("a", "b")
+        `shouldBe` Form (HashMap.singleton "k" ["a", "b"])
+    it "encodes the values of both fields in order" $
+      toFormVia sharedKeyCodec ("b", "a")
+        `shouldBe` Form (HashMap.singleton "k" ["b", "a"])
+
+  describe "decoding errors" $ do
+    it "names the key that is missing" $
+      (fromFormViaCodec emptyForm :: Either String Via)
+        `shouldBe` Left "Failed to parse key \"one\": expected exactly one value, found none."
+    it "names the key that has too many values and says how many" $
+      ( fromFormViaCodec (Form (HashMap.fromList [("one", ["a", "b"]), ("two", ["c"])])) ::
+          Either String Via
+      )
+        `shouldBe` Left "Failed to parse key \"one\": expected exactly one value, found 2."
+
+  describe "formDecodeSettingEmptyValue" $ do
+    -- Both fields present, both empty: one required, one optional.
+    let formWithEmptyValues =
+          Form $
+            HashMap.fromList
+              [ ("required-non-empty", [""]),
+                ("optional-non-empty", [""])
+              ]
+    let absentSettings =
+          defaultFormDecodeSettings
+            { formDecodeSettingEmptyValue = EmptyValueIsAbsent
+            }
+    it "reads an empty value as a value by default" $
+      fromFormViaCodec formWithEmptyValues
+        `shouldBe` Right
+          ListsExample
+            { listsExamplePossiblyEmptyWithOmittedDefault = [],
+              listsExamplePossiblyEmptyWithDefault = [],
+              listsExampleRequiredNonEmpty = "" :| [],
+              listsExampleOptionalNonEmpty = Just ("" :| [])
+            }
+    it "reads an empty value as absent only for the optional key" $
+      fromFormViaCodecWith absentSettings formWithEmptyValues
+        `shouldBe` Right
+          ListsExample
+            { listsExamplePossiblyEmptyWithOmittedDefault = [],
+              listsExamplePossiblyEmptyWithDefault = [],
+              listsExampleRequiredNonEmpty = "" :| [],
+              listsExampleOptionalNonEmpty = Nothing
+            }
+    it "leaves an empty value among non-empty ones alone" $
+      fromFormViaCodecWith
+        absentSettings
+        ( Form $
+            HashMap.fromList
+              [ ("required-non-empty", ["a"]),
+                ("optional-non-empty", ["", "b"])
+              ]
+        )
+        `shouldBe` Right
+          ListsExample
+            { listsExamplePossiblyEmptyWithOmittedDefault = [],
+              listsExamplePossiblyEmptyWithDefault = [],
+              listsExampleRequiredNonEmpty = "a" :| [],
+              listsExampleOptionalNonEmpty = Just ("" :| ["b"])
+            }
+    it "cannot express an optional field that is genuinely the empty string" $
+      let example =
+            ListsExample
+              { listsExamplePossiblyEmptyWithOmittedDefault = [],
+                listsExamplePossiblyEmptyWithDefault = [],
+                listsExampleRequiredNonEmpty = "a" :| [],
+                listsExampleOptionalNonEmpty = Just ("" :| [])
+              }
+       in fromFormViaCodecWith absentSettings (toFormViaCodec example)
+            `shouldBe` Right (example {listsExampleOptionalNonEmpty = Nothing})
+    it "falls back to the default of a field that has one" $
+      fromFormViaCodecWith
+        absentSettings
+        ( Form $
+            HashMap.fromList
+              [ ("required-non-empty", ["a"]),
+                ("possibly-empty-with-default", [""])
+              ]
+        )
+        `shouldBe` Right
+          ListsExample
+            { listsExamplePossiblyEmptyWithOmittedDefault = [],
+              listsExamplePossiblyEmptyWithDefault = [],
+              listsExampleRequiredNonEmpty = "a" :| [],
+              listsExampleOptionalNonEmpty = Nothing
+            }
+    it "does not change how a missing key reads" $
+      fromFormViaCodecWith absentSettings (Form (HashMap.singleton "required-non-empty" ["a"]))
+        `shouldBe` Right
+          ListsExample
+            { listsExamplePossiblyEmptyWithOmittedDefault = [],
+              listsExamplePossiblyEmptyWithDefault = [],
+              listsExampleRequiredNonEmpty = "a" :| [],
+              listsExampleOptionalNonEmpty = Nothing
+            }
+
+  formCodecSpec @Example
+  formCodecSpec @Via
+  formCodecSpec @LegacyValue
+  formCodecSpec @LegacyObject
+  formCodecSpec @These
+  formCodecSpec @Expression
+  formCodecSpec @ListsExample
+  formCodecSpec @Overlap
+
+formCodecSpec ::
+  forall a.
+  ( Show a,
+    Eq a,
+    Typeable a,
+    GenValid a,
+    ToForm a,
+    FromForm a,
+    HasObjectCodec a
+  ) =>
+  Spec
+formCodecSpec =
+  describe ("formCodecSpec " <> nameOf @a) $ do
+    it "matches the encoding" $
+      forAllValid $ \(a :: a) ->
+        let ctx =
+              unlines
+                [ "Encoded with this codec",
+                  showCodecABit (objectCodec @a)
+                ]
+            encodedViaInstance = toForm a
+            encodedViaCodec = toFormViaCodec a
+         in context ctx $ encodedViaCodec `shouldBe` encodedViaInstance
+    it "matches the decoding" $
+      forAllValid $ \(a :: a) ->
+        let encoded = toForm a
+            ctx =
+              unlines
+                [ "Encoded to this value:",
+                  ppShow encoded,
+                  "with this codec",
+                  showCodecABit (objectCodec @a)
+                ]
+            decodedWithInstance = fromForm encoded :: Either T.Text a
+            decodedWithAutodocodec = fromFormViaCodec encoded :: Either String a
+         in context ctx $ decodedWithAutodocodec `shouldBe` first T.unpack decodedWithInstance
+    codecSpec @a
+
+codecSpec ::
+  forall a.
+  ( Show a,
+    Eq a,
+    GenValid a,
+    HasObjectCodec a
+  ) =>
+  Spec
+codecSpec = do
+  it "roundtrips through Form via the codec" $
+    forAllValid $ \(a :: a) ->
+      let encoded = toFormViaCodec a
+          errOrDecoded = fromFormViaCodec encoded
+          ctx =
+            unlines
+              [ "Encoded to this value:",
+                ppShow encoded,
+                "with this codec",
+                showCodecABit (objectCodec @a)
+              ]
+       in context ctx $ case errOrDecoded of
+            Left err -> expectationFailure err
+            Right actual -> actual `shouldBe` a
+  it "roundtrips through the urlencoded wire format via the codec" $
+    forAllValid $ \(a :: a) ->
+      let encoded = urlEncodeFormStable (toFormViaCodec a)
+          errOrDecoded = urlDecodeForm encoded >>= first T.pack . fromFormViaCodec
+          ctx =
+            unlines
+              [ "Encoded to this value:",
+                ppShow encoded,
+                "with this codec",
+                showCodecABit (objectCodec @a)
+              ]
+       in context ctx $ case errOrDecoded of
+            Left err -> expectationFailure (T.unpack err)
+            Right actual -> actual `shouldBe` a

--- a/autodocodec-api-usage/test/Autodocodec/MultipartSpec.hs
+++ b/autodocodec-api-usage/test/Autodocodec/MultipartSpec.hs
@@ -33,6 +33,17 @@ deriving instance (Eq (MultipartResult tag)) => Eq (MultipartData tag)
 
 spec :: Spec
 spec = do
+  describe "decoding errors" $ do
+    it "names the key that is missing" $
+      (fromMultipartViaCodec memptyMultipartData :: Either String Via)
+        `shouldBe` Left "Failed to parse key \"one\": expected exactly one value, found none."
+    it "names the key that has too many values and says how many" $
+      ( fromMultipartViaCodec
+          (MultipartData [Input "one" "a", Input "one" "b", Input "two" "c"] []) ::
+          Either String Via
+      )
+        `shouldBe` Left "Failed to parse key \"one\": expected exactly one value, found 2."
+
   xdescribe "does not hold." $ multipartCodecSpec @Example
   multipartCodecSpec @Via
   multipartCodecSpec @LegacyValue

--- a/autodocodec-http-api-data/.gitignore
+++ b/autodocodec-http-api-data/.gitignore
@@ -1,0 +1,2 @@
+.stack-work/
+*~

--- a/autodocodec-http-api-data/CHANGELOG.md
+++ b/autodocodec-http-api-data/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [0.0.0.0] - 2026-08-24
+
+First version

--- a/autodocodec-http-api-data/LICENSE
+++ b/autodocodec-http-api-data/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Tom Sydney Kerckhove
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/autodocodec-http-api-data/autodocodec-http-api-data.cabal
+++ b/autodocodec-http-api-data/autodocodec-http-api-data.cabal
@@ -4,14 +4,14 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 
-name:           autodocodec-servant-multipart
-version:        0.0.0.4
-synopsis:       Autodocodec interpreters for Servant Multipart
+name:           autodocodec-http-api-data
+version:        0.0.0.0
+synopsis:       Autodocodec interpreters for http-api-data
 homepage:       https://github.com/NorfairKing/autodocodec#readme
 bug-reports:    https://github.com/NorfairKing/autodocodec/issues
 author:         Tom Sydney Kerckhove
 maintainer:     syd@cs-syd.eu
-copyright:      2022 Tom Sydney Kerckhove
+copyright:      2026 Tom Sydney Kerckhove
 license:        MIT
 license-file:   LICENSE
 build-type:     Simple
@@ -25,9 +25,9 @@ source-repository head
 
 library
   exposed-modules:
-      Autodocodec.Multipart
+      Autodocodec.FormUrlEncoded
   other-modules:
-      Paths_autodocodec_servant_multipart
+      Paths_autodocodec_http_api_data
   hs-source-dirs:
       src
   build-depends:
@@ -35,8 +35,7 @@ library
     , autodocodec >=0.6.0.0
     , base >=4.7 && <5
     , bytestring
-    , servant-multipart
-    , servant-multipart-api
+    , http-api-data
     , text
     , unordered-containers
     , vector

--- a/autodocodec-http-api-data/default.nix
+++ b/autodocodec-http-api-data/default.nix
@@ -1,0 +1,15 @@
+{ mkDerivation, aeson, autodocodec, base, bytestring, http-api-data
+, lib, text, unordered-containers, vector
+}:
+mkDerivation {
+  pname = "autodocodec-http-api-data";
+  version = "0.0.0.0";
+  src = ./.;
+  libraryHaskellDepends = [
+    aeson autodocodec base bytestring http-api-data text
+    unordered-containers vector
+  ];
+  homepage = "https://github.com/NorfairKing/autodocodec#readme";
+  description = "Autodocodec interpreters for http-api-data";
+  license = lib.licenses.mit;
+}

--- a/autodocodec-http-api-data/package.yaml
+++ b/autodocodec-http-api-data/package.yaml
@@ -1,11 +1,11 @@
-name: autodocodec-servant-multipart
-version: 0.0.0.4
+name: autodocodec-http-api-data
+version: 0.0.0.0
 github: "NorfairKing/autodocodec"
 license: MIT
 author: "Tom Sydney Kerckhove"
 maintainer: "syd@cs-syd.eu"
-copyright: "2022 Tom Sydney Kerckhove"
-synopsis: Autodocodec interpreters for Servant Multipart
+copyright: "2026 Tom Sydney Kerckhove"
+synopsis: Autodocodec interpreters for http-api-data
 
 extra-source-files:
 - LICENSE
@@ -20,8 +20,7 @@ library:
   - aeson
   - autodocodec >=0.6.0.0
   - bytestring
-  - servant-multipart
-  - servant-multipart-api
+  - http-api-data
   - text
   - unordered-containers
   - vector

--- a/autodocodec-http-api-data/src/Autodocodec/FormUrlEncoded.hs
+++ b/autodocodec-http-api-data/src/Autodocodec/FormUrlEncoded.hs
@@ -1,0 +1,297 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- | Interpret an 'ObjectCodec' as a @application/x-www-form-urlencoded@ 'Form'.
+--
+-- A 'Form' is flat: a map from keys to lists of text values.
+-- Consequently:
+--
+-- * A nested object or array is JSON-encoded into the text slot of its key.
+--   That round-trips through this module but no other form parser will
+--   understand it.
+-- * A field is absent exactly when its key is absent; a 'Form' has no @null@
+--   of its own. See 'EmptyValue' if you need @key=@ to mean absent as well,
+--   which is a decoder setting because only an optional key can be absent.
+-- * An optional field holding an empty list decodes as absent rather than as
+--   the empty list, because a key with no values is not something a form can
+--   carry. Use a required field, or a non-empty list, if you need to tell those
+--   apart.
+module Autodocodec.FormUrlEncoded where
+
+import Autodocodec
+import Data.Aeson as JSON
+import Data.Aeson.Types as JSON
+import Data.Bifunctor (first)
+import qualified Data.ByteString.Lazy as LB
+import Data.Coerce (coerce)
+import Data.Foldable
+import qualified Data.HashMap.Strict as HashMap
+import Data.Maybe
+import Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as TE
+import Data.Vector (Vector)
+import qualified Data.Vector as V
+import Web.FormUrlEncoded
+
+toFormViaCodec :: forall a. (HasObjectCodec a) => a -> Form
+toFormViaCodec = toFormVia (objectCodec @a)
+
+toFormVia :: ObjectCodec a void -> a -> Form
+toFormVia = flip go
+  where
+    go :: a -> ObjectCodec a void -> Form
+    go a = \case
+      BimapCodec _ to c -> go (to a) c
+      EitherCodec _ c1 c2 -> case coerce a of
+        Left a1 -> go a1 c1
+        Right a2 -> go a2 c2
+      DiscriminatedUnionCodec discriminator encoding _ ->
+        let (discriminatorValue, c) = encoding a
+         in unionForm
+              (singletonForm discriminator [discriminatorValue])
+              (go a c)
+      RequiredKeyCodec key vc _ -> singletonForm key (goValue (coerce a) vc)
+      OptionalKeyCodec key vc _ ->
+        singletonForm key $ do
+          a' <- maybeToList $ coerce a
+          goValue a' vc
+      OptionalKeyWithDefaultCodec key vc _ _ -> singletonForm key (goValue a vc)
+      OptionalKeyWithOmittedDefaultCodec key vc defaultValue _ ->
+        if coerce a == defaultValue
+          then emptyForm
+          else singletonForm key (goValue (coerce a) vc)
+      PureCodec _ -> emptyForm
+      ApCodec oc1 oc2 -> unionForm (go a oc1) (go a oc2)
+
+    goValue :: a -> ValueCodec a void -> [Text]
+    goValue a = \case
+      BimapCodec _ to vc -> goValue (to a) vc
+      EitherCodec _ c1 c2 -> case coerce a of
+        Left a1 -> goValue a1 c1
+        Right a2 -> goValue a2 c2
+      CommentCodec _ vc -> goValue a vc
+      ArrayOfCodec _ (vc :: ValueCodec input output) -> map (`goSingleValue` vc) (toList (coerce a :: Vector input))
+      vc -> [goSingleValue a vc]
+
+    goSingleValue :: a -> ValueCodec a void -> Text
+    goSingleValue a = \case
+      BimapCodec _ to vc -> goSingleValue (to a) vc
+      EitherCodec _ c1 c2 -> case coerce a of
+        Left a1 -> goSingleValue a1 c1
+        Right a2 -> goSingleValue a2 c2
+      CommentCodec _ vc -> goSingleValue a vc
+      NullCodec -> "null"
+      -- Lower case, to match @toUrlPiece \@Bool@ and the HTML form convention,
+      -- so that the value survives http-api-data's own parser.
+      BoolCodec _ ->
+        case coerce a of
+          True -> "true"
+          False -> "false"
+      StringCodec _ _ -> coerce a
+      vc ->
+        let value = toJSONVia vc a
+         in case value of
+              JSON.String t -> t
+              _ -> TE.decodeUtf8 (LB.toStrict (JSON.encode value))
+
+emptyForm :: Form
+emptyForm = Form HashMap.empty
+
+-- | A 'Form' with a single key, or 'emptyForm' if there are no values.
+--
+-- A key mapped to no values would encode to nothing anyway, so keeping it out
+-- of the map means a 'Form' is 'Eq' to one built by any other route.
+singletonForm :: Text -> [Text] -> Form
+singletonForm key = \case
+  [] -> emptyForm
+  ts -> Form (HashMap.singleton key ts)
+
+-- | Combine two 'Form's, keeping the values of both under a shared key.
+--
+-- Not '<>': 'Form' derives 'Semigroup' from 'HashMap', whose union is
+-- left-biased and would silently drop the second form's values.
+unionForm :: Form -> Form -> Form
+unionForm (Form h1) (Form h2) = Form (HashMap.unionWith (++) h1 h2)
+
+instance (HasObjectCodec a) => ToForm (Autodocodec a) where
+  toForm = toFormViaCodec . unAutodocodec
+
+-- | How to read a key that is present but whose every value is empty, as in
+-- @key=@.
+--
+-- This only ever applies to optional keys. A required key always decodes its
+-- value, empty or not, because there is no absence for it to mean.
+data EmptyValue
+  = -- | An empty value is a value, so @key=@ decodes as the empty string.
+    --
+    -- Lossless, and it agrees with 'lookupMaybe', which distinguishes a missing
+    -- key from an empty one.
+    EmptyValueIsValue
+  | -- | An empty value means the optional key is absent.
+    --
+    -- A shell substitutes the empty string for an unset variable, so
+    -- @curl --data-urlencode "key=$UNSET"@ sends @key=@ rather than nothing at
+    -- all. Choosing this makes an optional field that is genuinely the empty
+    -- string inexpressible.
+    EmptyValueIsAbsent
+
+data FormDecodeSettings = FormDecodeSettings
+  { formDecodeSettingEmptyValue :: !EmptyValue
+  }
+
+defaultFormDecodeSettings :: FormDecodeSettings
+defaultFormDecodeSettings =
+  FormDecodeSettings
+    { formDecodeSettingEmptyValue = EmptyValueIsValue
+    }
+
+fromFormViaCodec :: forall a. (HasObjectCodec a) => Form -> Either String a
+fromFormViaCodec = fromFormViaCodecWith defaultFormDecodeSettings
+
+fromFormViaCodecWith :: forall a. (HasObjectCodec a) => FormDecodeSettings -> Form -> Either String a
+fromFormViaCodecWith settings = fromFormViaWith settings (objectCodec @a)
+
+fromFormVia :: ObjectCodec void a -> Form -> Either String a
+fromFormVia = fromFormViaWith defaultFormDecodeSettings
+
+fromFormViaWith :: FormDecodeSettings -> ObjectCodec void a -> Form -> Either String a
+fromFormViaWith FormDecodeSettings {..} = flip go
+  where
+    -- Name the key in whatever failed under it. This error reaches whoever
+    -- posted the form, often as an HTTP response body, so "which key" is the
+    -- first thing it has to say.
+    inKey :: Text -> Either String b -> Either String b
+    inKey key = first $ \err -> concat ["Failed to parse key ", show key, ": ", err]
+
+    -- The values of an optional key, with 'formDecodeSettingEmptyValue'
+    -- applied. A key whose values are not all empty is left alone, so that an
+    -- empty element among non-empty ones is still an element.
+    lookupOptional :: Text -> Form -> [Text]
+    lookupOptional key form =
+      let values = lookupAll key form
+       in case formDecodeSettingEmptyValue of
+            EmptyValueIsValue -> values
+            EmptyValueIsAbsent
+              | all Text.null values -> []
+              | otherwise -> values
+
+    go :: Form -> ObjectCodec void a -> Either String a
+    go form = \case
+      BimapCodec from _ c -> go form c >>= from
+      EitherCodec u c1 c2 -> coerce $ case u of
+        PossiblyJointUnion ->
+          case go form c1 of
+            Right l -> pure (Left l)
+            Left err1 -> case go form c2 of
+              Left err2 -> Left $ concat ["  Previous branch failure: ", err1, "\n", err2]
+              Right r -> pure (Right r)
+        DisjointUnion ->
+          case (go form c1, go form c2) of
+            (Left _, Right r) -> pure (Right r)
+            (Right l, Left _) -> pure (Left l)
+            (Right _, Right _) -> Left "Both branches of a disjoint union succeeded."
+            (Left lErr, Left rErr) ->
+              Left $
+                unlines
+                  [ "Both branches of a disjoint union failed: ",
+                    unwords ["Left:  ", lErr],
+                    unwords ["Right: ", rErr]
+                  ]
+      DiscriminatedUnionCodec discriminator _ m -> do
+        discriminatorValue <- first Text.unpack $ lookupUnique discriminator form
+        case HashMap.lookup discriminatorValue m of
+          Nothing -> Left $ unwords ["Unexpected discriminator value:", show discriminatorValue]
+          Just (_, c) -> go form c
+      RequiredKeyCodec key vc _ -> inKey key $ coerce $ goValue (lookupAll key form) vc
+      OptionalKeyCodec key vc _ -> inKey key $ coerce $ case lookupOptional key form of
+        [] -> pure Nothing
+        values -> Just <$> goValue values vc
+      OptionalKeyWithDefaultCodec key vc defaultValue _ -> inKey key $ coerce $ case lookupOptional key form of
+        [] -> pure defaultValue
+        values -> goValue values vc
+      OptionalKeyWithOmittedDefaultCodec key vc defaultValue _ -> inKey key $ coerce $ case lookupOptional key form of
+        [] -> pure defaultValue
+        values -> goValue values vc
+      PureCodec v -> pure v
+      ApCodec ocf oca -> go form ocf <*> go form oca
+
+    goValue :: [Text] -> ValueCodec void a -> Either String a
+    goValue ts = \case
+      BimapCodec from _ c -> goValue ts c >>= from
+      EitherCodec u c1 c2 -> coerce $ case u of
+        PossiblyJointUnion ->
+          case goValue ts c1 of
+            Right l -> pure (Left l)
+            Left err1 -> case goValue ts c2 of
+              Left err2 -> Left $ concat ["  Previous branch failure: ", err1, "\n", err2]
+              Right r -> pure (Right r)
+        DisjointUnion ->
+          case (goValue ts c1, goValue ts c2) of
+            (Left _, Right r) -> pure (Right r)
+            (Right l, Left _) -> pure (Left l)
+            (Right _, Right _) -> Left "Both branches of a disjoint union succeeded."
+            (Left lErr, Left rErr) ->
+              Left $
+                unlines
+                  [ "Both branches of a disjoint union failed: ",
+                    unwords ["Left:  ", lErr],
+                    unwords ["Right: ", rErr]
+                  ]
+      ReferenceCodec _ vc -> goValue ts vc
+      CommentCodec _ c -> goValue ts c
+      ArrayOfCodec _ vc -> coerce $ V.fromList <$> mapM (`goSingleValue` vc) (toList ts)
+      vc -> case ts of
+        [t] -> goSingleValue t vc
+        [] -> Left "expected exactly one value, found none."
+        _ -> Left $ concat ["expected exactly one value, found ", show (length ts), "."]
+
+    goSingleValue :: Text -> ValueCodec void a -> Either String a
+    goSingleValue t = \case
+      BimapCodec from _ c -> goSingleValue t c >>= from
+      EitherCodec u c1 c2 -> coerce $ case u of
+        PossiblyJointUnion ->
+          case goSingleValue t c1 of
+            Right l -> pure (Left l)
+            Left err1 -> case goSingleValue t c2 of
+              Left err2 -> Left $ concat ["  Previous branch failure: ", err1, "\n", err2]
+              Right r -> pure (Right r)
+        DisjointUnion ->
+          case (goSingleValue t c1, goSingleValue t c2) of
+            (Left _, Right r) -> pure (Right r)
+            (Right l, Left _) -> pure (Left l)
+            (Right _, Right _) -> Left "Both branches of a disjoint union succeeded."
+            (Left lErr, Left rErr) ->
+              Left $
+                unlines
+                  [ "Both branches of a disjoint union failed: ",
+                    unwords ["Left:  ", lErr],
+                    unwords ["Right: ", rErr]
+                  ]
+      CommentCodec _ c -> goSingleValue t c
+      ReferenceCodec _ vc -> goSingleValue t vc
+      NullCodec -> coerce $ case t of
+        "null" -> Right ()
+        _ -> Left $ unwords ["not 'null':", show t]
+      BoolCodec _ -> coerce $ case t of
+        "false" -> Right False
+        "False" -> Right False
+        "true" -> Right True
+        "True" -> Right True
+        _ -> Left $ unwords ["Unknown bool:", show t]
+      StringCodec _ _ -> Right (coerce t)
+      vc -> case JSON.parseEither (parseJSONVia vc) (JSON.String t) of
+        Right a -> Right a
+        Left _ -> do
+          value <- JSON.eitherDecode (LB.fromStrict (TE.encodeUtf8 t))
+          JSON.parseEither (parseJSONVia vc) value
+
+instance (HasObjectCodec a) => FromForm (Autodocodec a) where
+  fromForm = first Text.pack . fmap Autodocodec . fromFormViaCodec

--- a/autodocodec-servant-multipart/CHANGELOG.md
+++ b/autodocodec-servant-multipart/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.0.0.4] - 2026-08-24
+
+### Changed
+
+* Decoding errors now name the key that failed, and say how many values were
+  found when exactly one was expected.
+
 ## [0.0.0.3] - 2026-07-14
 
 ### Changed

--- a/autodocodec-servant-multipart/default.nix
+++ b/autodocodec-servant-multipart/default.nix
@@ -4,7 +4,7 @@
 }:
 mkDerivation {
   pname = "autodocodec-servant-multipart";
-  version = "0.0.0.3";
+  version = "0.0.0.4";
   src = ./.;
   libraryHaskellDepends = [
     aeson autodocodec base bytestring servant-multipart

--- a/autodocodec-servant-multipart/src/Autodocodec/Multipart.hs
+++ b/autodocodec-servant-multipart/src/Autodocodec/Multipart.hs
@@ -13,6 +13,7 @@ module Autodocodec.Multipart where
 import Autodocodec
 import Data.Aeson as JSON
 import Data.Aeson.Types as JSON
+import Data.Bifunctor (first)
 import qualified Data.ByteString.Lazy as LB
 import Data.Coerce (coerce)
 import Data.Foldable
@@ -127,6 +128,12 @@ fromMultipartViaCodec = fromMultipartVia (objectCodec @a)
 fromMultipartVia :: ObjectCodec void a -> MultipartData tag -> Either String a
 fromMultipartVia = flip go
   where
+    -- Name the key in whatever failed under it. This error reaches whoever
+    -- submitted the form, often as an HTTP response body, so "which key" is the
+    -- first thing it has to say.
+    inKey :: Text -> Either String b -> Either String b
+    inKey key = first $ \err -> concat ["Failed to parse key ", show key, ": ", err]
+
     go :: MultipartData tag -> ObjectCodec void a -> Either String a
     go mpd = \case
       BimapCodec from _ c -> go mpd c >>= from
@@ -154,20 +161,20 @@ fromMultipartVia = flip go
         case HashMap.lookup discriminatorValue m of
           Nothing -> Left $ "Unexpected discriminator value: " <> show discriminatorValue
           Just (_, c) -> go mpd c
-      RequiredKeyCodec key vc _ -> do
+      RequiredKeyCodec key vc _ -> inKey key $ do
         values <- lookupLInput key mpd
         coerce $ goValue values vc
-      OptionalKeyCodec key vc _ -> do
+      OptionalKeyCodec key vc _ -> inKey key $ do
         values <- lookupLInput key mpd
         coerce $ case values of
           [] -> pure Nothing
           _ -> Just <$> goValue values vc
-      OptionalKeyWithDefaultCodec key vc defaultValue _ -> do
+      OptionalKeyWithDefaultCodec key vc defaultValue _ -> inKey key $ do
         values <- lookupLInput key mpd
         coerce $ case values of
           [] -> pure defaultValue
           _ -> goValue values vc
-      OptionalKeyWithOmittedDefaultCodec key vc defaultValue _ -> do
+      OptionalKeyWithOmittedDefaultCodec key vc defaultValue _ -> inKey key $ do
         values <- lookupLInput key mpd
         coerce $ case values of
           [] -> pure defaultValue
@@ -202,7 +209,8 @@ fromMultipartVia = flip go
       ArrayOfCodec _ vc -> coerce $ V.fromList <$> mapM (`goSingleValue` vc) (toList ts)
       vc -> case ts of
         [t] -> goSingleValue t vc
-        _ -> Left "Expected exactly one value."
+        [] -> Left "expected exactly one value, found none."
+        _ -> Left $ concat ["expected exactly one value, found ", show (length ts), "."]
 
     goSingleValue :: Text -> ValueCodec void a -> Either String a
     goSingleValue t = \case

--- a/nix/overrides.nix
+++ b/nix/overrides.nix
@@ -33,6 +33,7 @@ let
     autodocodec = autodocodecPkg "autodocodec";
     autodocodec-api-usage = autodocodecPkg "autodocodec-api-usage";
     autodocodec-exact = autodocodecPkg "autodocodec-exact";
+    autodocodec-http-api-data = autodocodecPkg "autodocodec-http-api-data";
     autodocodec-nix = autodocodecPkg "autodocodec-nix";
     autodocodec-openapi3 = autodocodecPkg "autodocodec-openapi3";
     autodocodec-schema = autodocodecPkg "autodocodec-schema";

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,7 @@ packages:
 - autodocodec
 - autodocodec-api-usage
 - autodocodec-exact
+- autodocodec-http-api-data
 - autodocodec-nix
 - autodocodec-openapi3
 - autodocodec-schema


### PR DESCRIPTION
Derives `Web.FormUrlEncoded.ToForm` and `FromForm` from a `HasObjectCodec`
instance, so a type with a codec can be posted as
`application/x-www-form-urlencoded` without a second, hand-written description
of its fields.

## Why

The motivating case is an API endpoint that a shell should be able to hit with
curl alone:

```
curl --netrc --silent --show-error --fail-with-body \
  --data-urlencode "clone-url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git" \
  --data-urlencode "message=$COMMIT_MESSAGE" \
  https://api.nix-ci.com/suite
```

The point of the form is that `--data-urlencode` escapes each value, so a commit
message containing a quote or a newline needs no JSON encoder in the shell.

The type already had a `HasObjectCodec` instance naming all its fields, but with
no autodocodec support the `FromForm` instance had to be written by hand, so the
field names were spelled twice and a test had to assert the two lists agreed.
That test is exactly the check this package makes unnecessary.

`http-api-data`'s own generic derivation is not a substitute: it derives names
from Haskell record fields via a label modifier, so it would be a third
independent spelling of the same names rather than a shared one.

## What

`autodocodec-servant-multipart`'s interpreter retargeted at
`Web.FormUrlEncoded.Form`, which is likewise a flat map from text keys to text
values. A `Form`'s `HashMap Text [Text]` models repeated keys natively, so
`ArrayOfCodec` fits it better than it fits multipart's flat `[Input]`.

Three places where copying multipart verbatim would have been wrong:

- **`unionForm`, not `<>`.** `Form` newtype-derives `Semigroup` from `HashMap`,
  whose union is left-biased, so `<>` would silently drop the second form's
  values under a shared key — where multipart's `mappendMultipartData`
  concatenates.
- **Booleans encode lower case.** Multipart's encoder emits Haskell spelling;
  `toUrlPiece @Bool` is `T.toLower . show`, so `"True"` would round-trip through
  our own decoder but read as unconventional to every other form consumer. The
  decoder still accepts either spelling.
- **`key=` is a decoder setting.** A form has no null, so whether an empty value
  is the empty string or is absence is a real choice, and it is
  `FormDecodeSettings`:

  ```haskell
  data EmptyValue = EmptyValueIsValue | EmptyValueIsAbsent
  ```

  The decoder consults it **at optional keys only**. A required key has no
  absence for an empty value to mean, so it decodes the empty string either way.
  The default is `EmptyValueIsValue`, which is lossless and agrees with
  `lookupMaybe`. `EmptyValueIsAbsent` is for the shell case, where
  `--data-urlencode "x=$UNSET"` sends `x=`.

  That required/optional distinction exists nowhere but inside the interpreter,
  which is why the setting lives there rather than in a pre-pass over the
  `Form` — a pre-pass would strip a required field's legitimate empty string
  along with the optional field's unset one.

Nested values keep multipart's behaviour — JSON-encoded into the text slot —
documented in the module header as something no other form parser will
understand.

## Tests

`autodocodec-api-usage/test/Autodocodec/FormUrlEncodedSpec.hs` mirrors
`MultipartSpec`: "matches the encoding", "matches the decoding" and a round
trip, over `Example`, `Via`, `LegacyValue`, `LegacyObject`, `These`,
`Expression`, `ListsExample` and `Overlap`. Hand-written `ToForm`/`FromForm
Example` in `Usage.hs` give the first two something independent to compare
against, as the multipart pair do.

Beyond that mirror:

- Two assertions on a key that two fields share, which is the only shape that
  tells a values-concatenating union from a left-biased one. Without them,
  replacing `unionForm` with `<>` passed the entire suite.

- Four assertions on `formDecodeSettingEmptyValue`, using `ListsExample` because
  it has a required and an optional field in one type. The load-bearing one is
  that under `EmptyValueIsAbsent` a form with *both* fields present and empty
  still decodes the required field as `"" :| []` while the optional one becomes
  `Nothing`. I checked that this fails against a pre-pass implementation, which
  loses the required key with `Left "Expected a nonempty list, but got an empty
  list."`.
- A round trip through `urlEncodeFormStable`/`urlDecodeForm`, so the actual
  percent-escaped wire bytes are covered. That escaping is the reason the
  feature exists.

**No `xdescribe` was needed.** `MultipartSpec` skips `Example` with "does not
hold."; here the whole corpus round-trips, `Example` included. I ran 480,000
examples per property rather than trusting the default 100 before concluding
that. Grouping repeated keys is what makes the difference.

## Checks

- `nix flake check` passes. The new package builds under `-Werror` against
  nixpkgs 26.05, 25.11 and 25.05 plus horizon-advance, so against four
  `http-api-data` versions.
- Full `autodocodec-api-usage` suite: 77,483 examples, 0 failures.
- `pre-commit run -a` clean.

`stack build --pedantic` cannot pass in this tree, and not because of this
change: `autodocodec-swagger2` has an unused `aeson` dependency that
`-Wunused-packages` rejects under `-Werror`. I confirmed that on a clean tree
before working around it. It does not affect `nix flake check`, whose override
does not enable that warning, but it does mean the cheapest feedback loop is
unusable until a separate one-line fix to `autodocodec-swagger2/package.yaml`.

## Not in this PR

`cabal.project` needs no change (it globs `*/*.cabal`); `stack.yaml` does, since
it lists packages explicitly. Replacing the first hand-written caller lives in
the nix-ci tree, on branch `openapi-spec` (NorfairKing/nix-ci#463), which can
now use `fromFormViaCodecWith` with `EmptyValueIsAbsent` instead of its
hand-written instance.

## Known limitations

Documented in the module header rather than worked around:

- A nested object or array is JSON-encoded into the text slot of its key. It
  round-trips here, but no other form parser will understand it.
- An optional field holding an empty list decodes as absent, not as the empty
  list: a form cannot carry a key with zero values, so `Just []` and `Nothing`
  encode identically. Same in `autodocodec-servant-multipart`. Use a required
  field or a non-empty list to tell them apart.
- Under `EmptyValueIsAbsent`, an optional field that is genuinely the empty
  string is inexpressible. There is a test stating that loss rather than
  skipping the case.

## Where the coverage actually is

Worth knowing when reading the spec: for the seven types that derive via
`Autodocodec`, "matches the encoding" and "matches the decoding" compare
`toForm`/`fromForm` against the very functions those instances delegate to, so
they are tautologies. I confirmed this by making the encoder mangle every
required key — `Example`'s "matches the encoding" failed, every other type's
comparisons passed, and every round trip failed.

The structure is inherited from `MultipartSpec` and kept for maintainability,
but it means the real coverage is the round trips plus `Example`'s hand-written
`ToForm`/`FromForm`. Those are therefore built without the interpreter's own
`singletonForm`/`unionForm` helpers, so the comparison is two independent
spellings rather than one shared implementation.
